### PR TITLE
test: disposable npm git lock diagnostic

### DIFF
--- a/.github/workflows/v0.4.0-lockdiag.yml
+++ b/.github/workflows/v0.4.0-lockdiag.yml
@@ -1,0 +1,67 @@
+# Disposable npm lock-format diagnostic. Never merge.
+name: v0.4.0 npm git lock diagnostic
+
+on:
+  pull_request:
+    types: [opened]
+    branches: [agent/v0.4.0-dsh-extensions]
+
+permissions:
+  contents: read
+
+jobs:
+  inspect:
+    if: >-
+      github.repository_id == '1333633428' &&
+      github.event.sender.id == 223438451 &&
+      github.event.pull_request.user.id == 223438451 &&
+      github.event.pull_request.head.repo.id == 1333633428 &&
+      github.event.pull_request.base.repo.id == 1333633428 &&
+      github.event.pull_request.head.ref == 'e2e/v0.4.0-lockdiag' &&
+      github.event.pull_request.base.sha == '27cb420d7b4887a4f37720f853331fb90e989367'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Inspect npm's exact pinned-Git lock entry
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="$(mktemp -d)"
+          cleanup() {
+            docker run --rm --mount "type=bind,source=$root,target=/cleanup" \
+              docker.io/library/node:24.18.0-bookworm@sha256:5711a0d445a1af54af9589066c646df387d1831a608226f4cd694fc59e745059 \
+              rm -rf -- /cleanup/node_modules /cleanup/package.json /cleanup/package-lock.json || true
+            rmdir "$root" || true
+          }
+          trap cleanup EXIT
+          cat > "$root/package.json" <<'JSON'
+          {
+            "name": "dsh-lock-diagnostic",
+            "version": "1.0.0",
+            "private": true,
+            "dependencies": {
+              "dsh-action-v040-e2e-plugin": "git+https://github.com/Lixiaoyiao/deepseek-harness-action.git#b897a8fb648782b11100f7c5bc697e7c82c846e9"
+            }
+          }
+          JSON
+          docker run --rm --read-only --cap-drop ALL --security-opt no-new-privileges \
+            --user "$(id -u):$(id -g)" \
+            --network bridge \
+            --tmpfs /tmp:rw,nosuid,nodev,size=536870912 \
+            --mount "type=bind,source=$root,target=/work" \
+            --workdir /work \
+            --env HOME=/tmp --env npm_config_cache=/tmp/npm-cache \
+            docker.io/library/node:24.18.0-bookworm@sha256:5711a0d445a1af54af9589066c646df387d1831a608226f4cd694fc59e745059 \
+            npm install --no-audit --no-fund --omit=dev --ignore-scripts \
+              --install-strategy=nested --package-lock=true --lockfile-version=3 \
+              --omit-lockfile-registry-resolved=false --save=true --loglevel=error
+          node -e '
+            const lock = require(process.argv[1]);
+            const entry = lock.packages["node_modules/dsh-action-v040-e2e-plugin"];
+            console.log(JSON.stringify({
+              version: entry.version,
+              resolved: entry.resolved,
+              integrity: entry.integrity ?? null,
+              gitHead: entry.gitHead ?? null
+            }));
+          ' "$root/package-lock.json"


### PR DESCRIPTION
Disposable diagnostic for the Plugin runtime-lock failure found by real E2E. It prints only npm's public pinned-Git lock metadata and must never be merged.