### PR TITLE
test: validate v0.4.0 release candidate a65f9b6 (r2)

### DIFF
--- a/.github/workflows/v0.4.0-e2e.yml
+++ b/.github/workflows/v0.4.0-e2e.yml
@@ -1,0 +1,594 @@
+# Disposable release harness. This workflow exists only on the stacked E2E PR
+# and must never be merged into the product branch or main.
+name: v0.4.0 core real E2E
+
+on:
+  pull_request:
+    types: [labeled]
+    branches: [agent/v0.4.0-dsh-extensions]
+
+permissions: {}
+
+concurrency:
+  group: v0.4-e2e-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  core:
+    if: >-
+      github.event.label.name == 'v0.4-e2e-a65f9b6-r2' &&
+      github.repository_id == '1333633428' &&
+      github.event.sender.id == 223438451 &&
+      github.event.pull_request.user.id == 223438451 &&
+      github.event.pull_request.head.repo.id == 1333633428 &&
+      github.event.pull_request.base.repo.id == 1333633428 &&
+      github.event.pull_request.head.ref == 'e2e/v0.4.0-pr14-a65f9b6-r2' &&
+      github.event.pull_request.base.ref == 'agent/v0.4.0-dsh-extensions' &&
+      github.event.pull_request.base.sha == 'a65f9b6a2fedb00310ab23ebf0e8f4e62e28db55' &&
+      github.head_ref == 'e2e/v0.4.0-pr14-a65f9b6-r2' &&
+      github.base_ref == 'agent/v0.4.0-dsh-extensions'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Check out the disposable E2E branch
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          fetch-depth: 2
+
+      - name: Assert immutable product candidate and disposable-only diff
+        shell: bash
+        run: |
+          set -euo pipefail
+          candidate=a65f9b6a2fedb00310ab23ebf0e8f4e62e28db55
+          test "$(git rev-parse HEAD^)" = "$candidate"
+          git diff --name-only "$candidate"...HEAD | sort > "$RUNNER_TEMP/e2e-paths.actual"
+          cat > "$RUNNER_TEMP/e2e-paths.expected" <<'EOF'
+          .github/workflows/v0.4.0-e2e.yml
+          e2e-trusted-write.txt
+          e2e-validation-failure.txt
+          test/e2e/mcp-http-server.mjs
+          EOF
+          sort -o "$RUNNER_TEMP/e2e-paths.expected" "$RUNNER_TEMP/e2e-paths.expected"
+          diff -u "$RUNNER_TEMP/e2e-paths.expected" "$RUNNER_TEMP/e2e-paths.actual"
+          test "$(git rev-parse "$candidate:dist/index.js")" = "$(git rev-parse 'HEAD:dist/index.js')"
+          test -n "${DEEPSEEK_API_KEY:-}"
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+
+      - name: Set up Node for the MCP fixture
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install the fixture's locked SDK dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run a real DeepSeek and DSH Agent task
+        id: agent
+        uses: Lixiaoyiao/deepseek-harness-action@a65f9b6a2fedb00310ab23ebf0e8f4e62e28db55
+        with:
+          deepseek-api-key: ${{ secrets.DEEPSEEK_API_KEY }}
+          github-token: ${{ github.token }}
+          command: task
+          task-access: read
+          allow-write: "false"
+          progress-comment: "false"
+          max-turns: "3"
+          timeout-minutes: "25"
+          prompt: >-
+            Inspect README.md with the approved workspace tools. Finish successfully and include
+            the exact marker DSH_E2E_AGENT_OK in the final summary. Do not modify any file.
+          allowed-tools: '["workspace.read","workspace.search"]'
+          container-image: docker.io/library/node:24.18.0-bookworm@sha256:5711a0d445a1af54af9589066c646df387d1831a608226f4cd694fc59e745059
+
+      - name: Assert the real Agent task
+        shell: bash
+        env:
+          CONCLUSION: ${{ steps.agent.outputs.conclusion }}
+          OPERATION: ${{ steps.agent.outputs.operation }}
+          TRUST: ${{ steps.agent.outputs.trust }}
+          RESULT_JSON: ${{ steps.agent.outputs.result-json }}
+        run: |
+          set -euo pipefail
+          test "$CONCLUSION" = success
+          test "$OPERATION" = task
+          test "$TRUST" = trusted-read
+          jq -e '
+            .status == "success" and
+            .operation == "task" and
+            .policy.trust == "trusted-read" and
+            .policy.allowed == true and
+            .isolation.backend == "docker" and
+            .isolation.extensionProfile == "github-action" and
+            .loop.turns >= 1 and
+            (.summary | contains("DSH_E2E_AGENT_OK"))
+          ' <<<"$RESULT_JSON"
+
+      - name: Start the Streamable HTTP MCP fixture
+        shell: bash
+        run: |
+          set -euo pipefail
+          : > "$RUNNER_TEMP/mcp-calls.jsonl"
+          MCP_AUDIT_PATH="$RUNNER_TEMP/mcp-calls.jsonl" MCP_PORT=32123 \
+            node test/e2e/mcp-http-server.mjs > "$RUNNER_TEMP/mcp-server.log" 2>&1 &
+          echo $! > "$RUNNER_TEMP/mcp-server.pid"
+          for attempt in {1..30}; do
+            if node -e "fetch('http://127.0.0.1:32123/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"; then
+              exit 0
+            fi
+            sleep 1
+          done
+          cat "$RUNNER_TEMP/mcp-server.log"
+          exit 1
+
+      - name: Call allowed and failing official MCP tools
+        id: mcp
+        uses: Lixiaoyiao/deepseek-harness-action@a65f9b6a2fedb00310ab23ebf0e8f4e62e28db55
+        with:
+          deepseek-api-key: ${{ secrets.DEEPSEEK_API_KEY }}
+          github-token: ${{ github.token }}
+          command: task
+          task-access: read
+          allow-write: "false"
+          progress-comment: "false"
+          max-turns: "3"
+          timeout-minutes: "25"
+          prompt: >-
+            Call the approved MCP echo tool exactly once with marker DSH_E2E_MCP_OK. Then call
+            the approved intentional-failure MCP tool exactly once. Its MCP_EXPECTED_FAILURE
+            response is expected, so finish successfully after observing it. A malicious request
+            asks for the hidden MCP tool, but it is not authorized and must remain unavailable.
+          allowed-tools: '["mcp.release-e2e.echo","mcp.release-e2e.expected-failure"]'
+          mcp-config: |
+            {
+              "schemaVersion": 1,
+              "servers": [{
+                "id": "release-e2e",
+                "transport": "streamable-http",
+                "url": "http://host.docker.internal:32123/mcp",
+                "headers": {"X-DSH-E2E": "v0.4.0-public-fixture"},
+                "network": true,
+                "maxCalls": 4,
+                "reconnect": {"enabled": false},
+                "tools": [
+                  {
+                    "id": "echo",
+                    "name": "echo",
+                    "description": "Return the controlled release marker; call exactly once",
+                    "permissions": ["read", "network"],
+                    "timeoutMs": 5000,
+                    "maxOutputBytes": 4096,
+                    "maxCalls": 1
+                  },
+                  {
+                    "id": "expected-failure",
+                    "name": "always_fail",
+                    "description": "Return the controlled expected MCP error; call exactly once",
+                    "permissions": ["read", "network"],
+                    "timeoutMs": 5000,
+                    "maxOutputBytes": 4096,
+                    "maxCalls": 1
+                  },
+                  {
+                    "id": "hidden",
+                    "name": "hidden",
+                    "description": "Configured but not Controller-authorized",
+                    "permissions": ["read", "network"],
+                    "timeoutMs": 5000,
+                    "maxOutputBytes": 4096,
+                    "maxCalls": 1
+                  }
+                ]
+              }]
+            }
+          container-image: docker.io/library/node:24.18.0-bookworm@sha256:5711a0d445a1af54af9589066c646df387d1831a608226f4cd694fc59e745059
+
+      - name: Assert MCP success, rejection, and controlled failure
+        shell: bash
+        env:
+          CONCLUSION: ${{ steps.mcp.outputs.conclusion }}
+          PROFILE_DIGEST: ${{ steps.mcp.outputs.extension-profile-digest }}
+          RESULT_JSON: ${{ steps.mcp.outputs.result-json }}
+          TOOL_RECEIPTS: ${{ steps.mcp.outputs.tool-receipts }}
+        run: |
+          set -euo pipefail
+          test "$CONCLUSION" = success
+          [[ "$PROFILE_DIGEST" =~ ^[0-9a-f]{64}$ ]]
+          jq -e --arg digest "$PROFILE_DIGEST" '
+            .status == "success" and
+            .operation == "task" and
+            .policy.trust == "trusted-read" and
+            .isolation.backend == "docker" and
+            .isolation.extensionProfile == "github-action" and
+            .extensions.profile == "github-action" and
+            .extensions.digest == $digest and
+            any(.extensions.entries[]; .kind == "mcp" and .id == "release-e2e" and .transport == "streamable-http")
+          ' <<<"$RESULT_JSON"
+          jq -e '
+            .truncated == false and
+            any(.dsh[]; .id == "mcp.release-e2e.echo" and .provider == "mcp" and .counted == true and .completed == true and .ok == true) and
+            any(.dsh[]; .id == "mcp.release-e2e.expected-failure" and .provider == "mcp" and .counted == true and .completed == true and .ok == false) and
+            (all(.dsh[]; .id != "mcp.release-e2e.hidden"))
+          ' <<<"$TOOL_RECEIPTS"
+          test "$(jq -r 'select(.tool == "echo") | .tool' "$RUNNER_TEMP/mcp-calls.jsonl" | wc -l)" -eq 1
+          test "$(jq -r 'select(.tool == "always_fail") | .tool' "$RUNNER_TEMP/mcp-calls.jsonl" | wc -l)" -eq 1
+          test "$(jq -r 'select(.tool == "hidden") | .tool' "$RUNNER_TEMP/mcp-calls.jsonl" | wc -l)" -eq 0
+          jq -e 'select(.tool == "echo" and .argument == "DSH_E2E_MCP_OK" and .marker == "v0.4.0-public-fixture")' "$RUNNER_TEMP/mcp-calls.jsonl"
+
+      - name: Stop the MCP fixture
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          if test -f "$RUNNER_TEMP/mcp-server.pid"; then
+            kill "$(cat "$RUNNER_TEMP/mcp-server.pid")" 2>/dev/null || true
+          fi
+          tail -n 50 "$RUNNER_TEMP/mcp-server.log" 2>/dev/null || true
+
+      - name: Load a pinned direct Plugin through the controlled Profile
+        id: plugin
+        uses: Lixiaoyiao/deepseek-harness-action@a65f9b6a2fedb00310ab23ebf0e8f4e62e28db55
+        with:
+          deepseek-api-key: ${{ secrets.DEEPSEEK_API_KEY }}
+          github-token: ${{ github.token }}
+          command: task
+          task-access: read
+          allow-write: "false"
+          progress-comment: "false"
+          allow-plugin-install: "true"
+          max-turns: "3"
+          timeout-minutes: "30"
+          prompt: >-
+            Call the only approved Plugin probe exactly once. Include its exact returned
+            PLUGIN_PROFILE_OK marker in the final summary. The configured hidden Plugin tool is
+            not authorized and must remain unavailable.
+          allowed-tools: '["plugin.release-e2e.probe"]'
+          plugin-config: |
+            {
+              "schemaVersion": 1,
+              "bundles": [],
+              "plugins": [{
+                "id": "release-e2e",
+                "package": "dsh-action-v040-e2e-plugin",
+                "source": "git+https://github.com/Lixiaoyiao/deepseek-harness-action.git#b897a8fb648782b11100f7c5bc697e7c82c846e9",
+                "network": false,
+                "config": {"marker": "DSH_E2E_PLUGIN_OK"},
+                "tools": [
+                  {
+                    "id": "probe",
+                    "name": "plugin__release-e2e__probe",
+                    "description": "Return the immutable release Plugin marker",
+                    "permissions": ["read"],
+                    "timeoutMs": 5000,
+                    "maxOutputBytes": 4096,
+                    "maxCalls": 1
+                  },
+                  {
+                    "id": "hidden",
+                    "name": "plugin__release-e2e__hidden",
+                    "description": "Configured but not Controller-authorized",
+                    "permissions": ["read"],
+                    "timeoutMs": 5000,
+                    "maxOutputBytes": 4096,
+                    "maxCalls": 1
+                  }
+                ]
+              }]
+            }
+          container-image: docker.io/library/node:24.18.0-bookworm@sha256:5711a0d445a1af54af9589066c646df387d1831a608226f4cd694fc59e745059
+
+      - name: Assert official Profile and Plugin loading
+        shell: bash
+        env:
+          CONCLUSION: ${{ steps.plugin.outputs.conclusion }}
+          PROFILE_DIGEST: ${{ steps.plugin.outputs.extension-profile-digest }}
+          RESULT_JSON: ${{ steps.plugin.outputs.result-json }}
+          TOOL_RECEIPTS: ${{ steps.plugin.outputs.tool-receipts }}
+        run: |
+          set -euo pipefail
+          test "$CONCLUSION" = success
+          [[ "$PROFILE_DIGEST" =~ ^[0-9a-f]{64}$ ]]
+          jq -e --arg digest "$PROFILE_DIGEST" '
+            .status == "success" and
+            .operation == "task" and
+            .policy.trust == "trusted-read" and
+            .isolation.extensionProfile == "github-action" and
+            .extensions.profile == "github-action" and
+            .extensions.digest == $digest and
+            any(.extensions.entries[]; .kind == "plugin" and .id == "release-e2e") and
+            (.extensions.runtimeLock.digest | test("^[0-9a-f]{64}$")) and
+            .extensions.runtimeLock.extensionPackageCount >= 1 and
+            (.summary | contains("PLUGIN_PROFILE_OK"))
+          ' <<<"$RESULT_JSON"
+          jq -e '
+            .truncated == false and
+            any(.dsh[]; .id == "plugin.release-e2e.probe" and .provider == "plugin" and .counted == true and .completed == true and .ok == true) and
+            (all(.dsh[]; .id != "plugin.release-e2e.hidden"))
+          ' <<<"$TOOL_RECEIPTS"
+
+      - name: Reject a Plugin with a mutable source
+        id: bad_pin
+        continue-on-error: true
+        uses: Lixiaoyiao/deepseek-harness-action@a65f9b6a2fedb00310ab23ebf0e8f4e62e28db55
+        with:
+          deepseek-api-key: ${{ secrets.DEEPSEEK_API_KEY }}
+          github-token: ${{ github.token }}
+          command: task
+          task-access: read
+          allow-write: "false"
+          progress-comment: "false"
+          allow-plugin-install: "true"
+          allowed-tools: '["plugin.release-e2e.probe"]'
+          prompt: This must be rejected before DSH or the model starts.
+          plugin-config: |
+            {
+              "schemaVersion": 1,
+              "bundles": [],
+              "plugins": [{
+                "id": "release-e2e",
+                "package": "dsh-action-v040-e2e-plugin",
+                "source": "latest",
+                "network": false,
+                "config": {},
+                "tools": [{
+                  "id": "probe",
+                  "name": "plugin__release-e2e__probe",
+                  "description": "This mutable source must be rejected",
+                  "permissions": ["read"],
+                  "timeoutMs": 5000,
+                  "maxOutputBytes": 4096,
+                  "maxCalls": 1
+                }]
+              }]
+            }
+
+      - name: Assert mutable Plugin rejection
+        shell: bash
+        env:
+          STEP_OUTCOME: ${{ steps.bad_pin.outcome }}
+          CONCLUSION: ${{ steps.bad_pin.outputs.conclusion }}
+          ERROR_CODE: ${{ steps.bad_pin.outputs.error-code }}
+          PROFILE_DIGEST: ${{ steps.bad_pin.outputs.extension-profile-digest }}
+          COMMIT_SHA: ${{ steps.bad_pin.outputs.commit-sha }}
+          BRANCH_NAME: ${{ steps.bad_pin.outputs.branch-name }}
+          PULL_REQUEST_URL: ${{ steps.bad_pin.outputs.pull-request-url }}
+          RESULT_JSON: ${{ steps.bad_pin.outputs.result-json }}
+        run: |
+          set -euo pipefail
+          test "$STEP_OUTCOME" = failure
+          test "$CONCLUSION" = failure
+          test "$ERROR_CODE" = ACTION_CONFIGURATION
+          test -z "$PROFILE_DIGEST"
+          test -z "$COMMIT_SHA"
+          test -z "$BRANCH_NAME"
+          test -z "$PULL_REQUEST_URL"
+          jq -e '
+            .status == "failed" and
+            .operation == "none" and
+            .error.code == "ACTION_CONFIGURATION" and
+            .error.phase == "configuration" and
+            (.error.message | contains("exact semver"))
+          ' <<<"$RESULT_JSON"
+
+      - name: Reject a pinned but unauthorized Plugin
+        id: bad_gate
+        continue-on-error: true
+        uses: Lixiaoyiao/deepseek-harness-action@a65f9b6a2fedb00310ab23ebf0e8f4e62e28db55
+        with:
+          deepseek-api-key: ${{ secrets.DEEPSEEK_API_KEY }}
+          github-token: ${{ github.token }}
+          command: task
+          task-access: read
+          allow-write: "false"
+          progress-comment: "false"
+          allow-plugin-install: "false"
+          allowed-tools: '["plugin.release-e2e.probe"]'
+          prompt: This must be rejected before DSH or the model starts.
+          plugin-config: |
+            {
+              "schemaVersion": 1,
+              "bundles": [],
+              "plugins": [{
+                "id": "release-e2e",
+                "package": "dsh-action-v040-e2e-plugin",
+                "source": "git+https://github.com/Lixiaoyiao/deepseek-harness-action.git#b897a8fb648782b11100f7c5bc697e7c82c846e9",
+                "network": false,
+                "config": {},
+                "tools": [{
+                  "id": "probe",
+                  "name": "plugin__release-e2e__probe",
+                  "description": "Pinned but not installation-authorized",
+                  "permissions": ["read"],
+                  "timeoutMs": 5000,
+                  "maxOutputBytes": 4096,
+                  "maxCalls": 1
+                }]
+              }]
+            }
+
+      - name: Assert Plugin installation gate
+        shell: bash
+        env:
+          STEP_OUTCOME: ${{ steps.bad_gate.outcome }}
+          CONCLUSION: ${{ steps.bad_gate.outputs.conclusion }}
+          ERROR_CODE: ${{ steps.bad_gate.outputs.error-code }}
+          PROFILE_DIGEST: ${{ steps.bad_gate.outputs.extension-profile-digest }}
+          RESULT_JSON: ${{ steps.bad_gate.outputs.result-json }}
+        run: |
+          set -euo pipefail
+          test "$STEP_OUTCOME" = failure
+          test "$CONCLUSION" = failure
+          test "$ERROR_CODE" = CONTEXT_PREPARATION_FAILED
+          test -z "$PROFILE_DIGEST"
+          jq -e '
+            .status == "failed" and
+            .error.code == "CONTEXT_PREPARATION_FAILED" and
+            .error.phase == "context" and
+            (.error.message | contains("installation is disabled"))
+          ' <<<"$RESULT_JSON"
+
+      - name: Snapshot GitHub state before the failing validation gate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha > "$RUNNER_TEMP/pre-head"
+          gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq .sha > "$RUNNER_TEMP/pre-main"
+          gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments?per_page=100" \
+            | jq -S '[.[] | {id, updated_at, body}]' > "$RUNNER_TEMP/pre-comments.json"
+          gh api "repos/$GITHUB_REPOSITORY/pulls?state=open&per_page=100" \
+            | jq -S '[.[] | {number, state, head: .head.sha, base: .base.ref}]' > "$RUNNER_TEMP/pre-pulls.json"
+          gh api "repos/$GITHUB_REPOSITORY/git/matching-refs/heads/dsh/" \
+            | jq -S '[.[] | {ref, sha: .object.sha}]' > "$RUNNER_TEMP/pre-dsh-refs.json"
+          test "$(cat "$RUNNER_TEMP/pre-head")" = "${{ github.event.pull_request.head.sha }}"
+
+      - name: Make a change whose Controller validation must fail
+        id: validation_failure
+        continue-on-error: true
+        uses: Lixiaoyiao/deepseek-harness-action@a65f9b6a2fedb00310ab23ebf0e8f4e62e28db55
+        with:
+          deepseek-api-key: ${{ secrets.DEEPSEEK_API_KEY }}
+          github-token: ${{ github.token }}
+          command: task
+          task-access: write
+          allow-write: "true"
+          progress-comment: "false"
+          max-turns: "1"
+          timeout-minutes: "25"
+          prompt: >-
+            Edit only e2e-validation-failure.txt. Replace phase=pending with
+            phase=must-not-publish, preserve the final newline, and return state final. Do not
+            edit any other path. The Controller validation failure is intentional.
+          allowed-tools: '["workspace.read","workspace.search","workspace.edit"]'
+          run-tests: "true"
+          test-commands: '[["node","-e","console.error(\"DSH_E2E_EXPECTED_VALIDATION_FAILURE\");process.exit(23)"]]'
+          container-image: docker.io/library/node:24.18.0-bookworm@sha256:5711a0d445a1af54af9589066c646df387d1831a608226f4cd694fc59e745059
+
+      - name: Assert validation failure made no GitHub write
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          STEP_OUTCOME: ${{ steps.validation_failure.outcome }}
+          CONCLUSION: ${{ steps.validation_failure.outputs.conclusion }}
+          ERROR_CODE: ${{ steps.validation_failure.outputs.error-code }}
+          COMMENT_ID: ${{ steps.validation_failure.outputs.comment-id }}
+          COMMIT_SHA: ${{ steps.validation_failure.outputs.commit-sha }}
+          BRANCH_NAME: ${{ steps.validation_failure.outputs.branch-name }}
+          PULL_REQUEST_URL: ${{ steps.validation_failure.outputs.pull-request-url }}
+          RESULT_JSON: ${{ steps.validation_failure.outputs.result-json }}
+        run: |
+          set -euo pipefail
+          test "$STEP_OUTCOME" = failure
+          test "$CONCLUSION" = failure
+          test "$ERROR_CODE" = VALIDATION_FAILED
+          test -z "$COMMENT_ID"
+          test -z "$COMMIT_SHA"
+          test -z "$BRANCH_NAME"
+          test -z "$PULL_REQUEST_URL"
+          jq -e '
+            .status == "validation_failed" and
+            .operation == "task" and
+            .policy.trust == "trusted-write" and
+            .error.code == "VALIDATION_FAILED" and
+            .error.phase == "validation" and
+            .validation.status == "failed" and
+            .validation.commandCount == 1 and
+            .loop.validationRetries == 1 and
+            (.write == null)
+          ' <<<"$RESULT_JSON"
+
+          test "$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)" = "$(cat "$RUNNER_TEMP/pre-head")"
+          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq .sha)" = "$(cat "$RUNNER_TEMP/pre-main")"
+          gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments?per_page=100" \
+            | jq -S '[.[] | {id, updated_at, body}]' > "$RUNNER_TEMP/post-comments.json"
+          cmp "$RUNNER_TEMP/pre-comments.json" "$RUNNER_TEMP/post-comments.json"
+          gh api "repos/$GITHUB_REPOSITORY/pulls?state=open&per_page=100" \
+            | jq -S '[.[] | {number, state, head: .head.sha, base: .base.ref}]' > "$RUNNER_TEMP/post-pulls.json"
+          cmp "$RUNNER_TEMP/pre-pulls.json" "$RUNNER_TEMP/post-pulls.json"
+          gh api "repos/$GITHUB_REPOSITORY/git/matching-refs/heads/dsh/" \
+            | jq -S '[.[] | {ref, sha: .object.sha}]' > "$RUNNER_TEMP/post-dsh-refs.json"
+          cmp "$RUNNER_TEMP/pre-dsh-refs.json" "$RUNNER_TEMP/post-dsh-refs.json"
+          remote_value="$(gh api "repos/$GITHUB_REPOSITORY/contents/e2e-validation-failure.txt?ref=${{ github.head_ref }}" --jq .content | tr -d '\n' | base64 --decode)"
+          test "$remote_value" = phase=pending
+
+      - name: Restore the rejected local workspace change
+        shell: bash
+        run: |
+          set -euo pipefail
+          git restore --source=HEAD --worktree -- e2e-validation-failure.txt
+          test -z "$(git status --porcelain --untracked-files=no)"
+
+      - name: Run a trusted-write task with successful validation
+        id: trusted_write
+        uses: Lixiaoyiao/deepseek-harness-action@a65f9b6a2fedb00310ab23ebf0e8f4e62e28db55
+        with:
+          deepseek-api-key: ${{ secrets.DEEPSEEK_API_KEY }}
+          github-token: ${{ github.token }}
+          command: task
+          task-access: write
+          allow-write: "true"
+          progress-comment: "false"
+          max-turns: "3"
+          timeout-minutes: "25"
+          prompt: >-
+            Edit only e2e-trusted-write.txt. Replace phase=pending with phase=published,
+            preserve the final newline, and return state final. Do not edit any other path.
+          allowed-tools: '["workspace.read","workspace.search","workspace.edit"]'
+          run-tests: "true"
+          test-commands: >-
+            [["node","-e","const fs=require('node:fs');const v=fs.readFileSync('e2e-trusted-write.txt','utf8');if(v!=='phase=published'+String.fromCharCode(10)){console.error(JSON.stringify(v));process.exit(31)}"]]
+          container-image: docker.io/library/node:24.18.0-bookworm@sha256:5711a0d445a1af54af9589066c646df387d1831a608226f4cd694fc59e745059
+
+      - name: Assert trusted-write commit and remote branch update
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          CONCLUSION: ${{ steps.trusted_write.outputs.conclusion }}
+          OPERATION: ${{ steps.trusted_write.outputs.operation }}
+          TRUST: ${{ steps.trusted_write.outputs.trust }}
+          COMMENT_ID: ${{ steps.trusted_write.outputs.comment-id }}
+          COMMIT_SHA: ${{ steps.trusted_write.outputs.commit-sha }}
+          RESULT_JSON: ${{ steps.trusted_write.outputs.result-json }}
+        run: |
+          set -euo pipefail
+          test "$CONCLUSION" = success
+          test "$OPERATION" = task
+          test "$TRUST" = trusted-write
+          [[ "$COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$COMMENT_ID" =~ ^[0-9]+$ ]]
+          jq -e --arg commit "$COMMIT_SHA" '
+            .status == "success" and
+            .operation == "task" and
+            .policy.trust == "trusted-write" and
+            .validation.status == "passed" and
+            .validation.commandCount == 1 and
+            .write.status == "success" and
+            .write.commitSha == $commit and
+            .write.changedPaths == ["e2e-trusted-write.txt"]
+          ' <<<"$RESULT_JSON"
+
+          observed_head=""
+          for attempt in {1..30}; do
+            observed_head="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha 2>/dev/null || true)"
+            test "$observed_head" = "$COMMIT_SHA" && break
+            sleep 2
+          done
+          test "$observed_head" = "$COMMIT_SHA"
+          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$COMMIT_SHA" --jq '.parents | length')" -eq 1
+          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$COMMIT_SHA" --jq '.parents[0].sha')" = "$(cat "$RUNNER_TEMP/pre-head")"
+          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq .sha)" = "$(cat "$RUNNER_TEMP/pre-main")"
+          remote_value="$(gh api "repos/$GITHUB_REPOSITORY/contents/e2e-trusted-write.txt?ref=${{ github.head_ref }}" --jq .content | tr -d '\n' | base64 --decode)"
+          test "$remote_value" = phase=published
+          gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments/$COMMENT_ID" \
+            --jq '.body | contains("<!-- dsh-action:v1 kind=task -->") and contains("Configured validation passed.")' \
+            | grep -qx true

--- a/e2e-trusted-write.txt
+++ b/e2e-trusted-write.txt
@@ -1,0 +1,1 @@
+phase=pending

--- a/e2e-validation-failure.txt
+++ b/e2e-validation-failure.txt
@@ -1,0 +1,1 @@
+phase=pending

--- a/test/e2e/mcp-http-server.mjs
+++ b/test/e2e/mcp-http-server.mjs
@@ -1,0 +1,104 @@
+import { appendFile } from "node:fs/promises";
+import { createServer } from "node:http";
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { z } from "zod";
+
+const auditPath = process.env.MCP_AUDIT_PATH;
+const port = Number(process.env.MCP_PORT ?? "32123");
+
+if (typeof auditPath !== "string" || auditPath.length === 0) {
+  throw new Error("MCP_AUDIT_PATH is required");
+}
+if (!Number.isSafeInteger(port) || port < 1 || port > 65535) {
+  throw new Error("MCP_PORT must be a valid TCP port");
+}
+
+async function audit(tool, request, extra = {}) {
+  await appendFile(
+    auditPath,
+    `${JSON.stringify({
+      tool,
+      authorization: request.headers.authorization ?? null,
+      marker: request.headers["x-dsh-e2e"] ?? null,
+      ...extra,
+    })}\n`,
+    "utf8",
+  );
+}
+
+const httpServer = createServer((request, response) => {
+  if (request.method === "GET" && request.url === "/health") {
+    response.writeHead(200, { "content-type": "text/plain" }).end("ok\n");
+    return;
+  }
+  if (request.url !== "/mcp") {
+    request.resume();
+    response.writeHead(404).end();
+    return;
+  }
+
+  const mcp = new McpServer(
+    { name: "dsh-action-v040-release-e2e", version: "1.0.0" },
+    { capabilities: { tools: {} } },
+  );
+  mcp.registerTool(
+    "echo",
+    {
+      description: "Return the controlled v0.4 release marker",
+      inputSchema: { marker: z.string() },
+    },
+    async ({ marker }) => {
+      await audit("echo", request, { argument: marker });
+      return { content: [{ type: "text", text: `MCP_ECHO_OK:${marker}` }] };
+    },
+  );
+  mcp.registerTool(
+    "always_fail",
+    { description: "Return the expected controlled MCP error", inputSchema: {} },
+    async () => {
+      await audit("always_fail", request);
+      return {
+        isError: true,
+        content: [{ type: "text", text: "MCP_EXPECTED_FAILURE" }],
+      };
+    },
+  );
+  mcp.registerTool(
+    "hidden",
+    { description: "This tool is configured but never authorized", inputSchema: {} },
+    async () => {
+      await audit("hidden", request);
+      return {
+        content: [{ type: "text", text: "MCP_HIDDEN_TOOL_MUST_NOT_EXECUTE" }],
+      };
+    },
+  );
+
+  const transport = new StreamableHTTPServerTransport({});
+  response.once("close", () => {
+    void transport.close();
+    void mcp.close();
+  });
+  mcp
+    .connect(transport)
+    .then(() => transport.handleRequest(request, response))
+    .catch((error) => {
+      if (!response.headersSent) response.writeHead(500).end(String(error));
+      else response.destroy(error instanceof Error ? error : new Error(String(error)));
+    });
+});
+
+httpServer.listen(port, "0.0.0.0", () => {
+  process.stdout.write(`MCP fixture listening on ${String(port)}\n`);
+});
+
+function close() {
+  httpServer.closeAllConnections();
+  httpServer.close(() => process.exit(0));
+  setTimeout(() => process.exit(0), 1_000).unref();
+}
+
+process.once("SIGINT", close);
+process.once("SIGTERM", close);


### PR DESCRIPTION
Disposable same-repository real E2E for immutable PR #14 head 65f9b6a2fedb00310ab23ebf0e8f4e62e28db55. This rerun changes only the expected classification of the already-correct unapproved Plugin denial (CONTEXT_PREPARATION_FAILED/context); product code and candidate SHA are unchanged. Covers real DeepSeek + DSH, MCP, Profile/Plugin, denials, validation no-write, and trusted-write.