### PR TITLE
ci: bootstrap trusted core E2E harness

### DIFF
--- a/.github/e2e/hanging-http-server.mjs
+++ b/.github/e2e/hanging-http-server.mjs
@@ -1,0 +1,42 @@
+import { createServer } from "node:http";
+
+const sockets = new Set();
+const responses = new Set();
+const server = createServer((request, response) => {
+  if (request.method === "GET" && request.url === "/health") {
+    response.writeHead(200, { "content-type": "text/plain" }).end("ok\n");
+    return;
+  }
+
+  request.resume();
+  responses.add(response);
+  response.on("close", () => responses.delete(response));
+});
+server.requestTimeout = 0;
+server.headersTimeout = 0;
+server.keepAliveTimeout = 0;
+server.on("connection", (socket) => {
+  sockets.add(socket);
+  socket.on("close", () => sockets.delete(socket));
+});
+
+server.listen(0, "127.0.0.1", () => {
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("Expected a TCP listener");
+  }
+  process.stdout.write(
+    `${JSON.stringify({
+      baseUrl: `http://127.0.0.1:${String(address.port)}`,
+      healthUrl: `http://127.0.0.1:${String(address.port)}/health`,
+    })}\n`,
+  );
+});
+
+function shutdown() {
+  for (const response of responses) response.destroy();
+  for (const socket of sockets) socket.destroy();
+  server.close(() => process.exit(0));
+}
+process.once("SIGINT", shutdown);
+process.once("SIGTERM", shutdown);

--- a/.github/e2e/mcp-http-server.mjs
+++ b/.github/e2e/mcp-http-server.mjs
@@ -1,0 +1,85 @@
+import { appendFile } from "node:fs/promises";
+import { createServer } from "node:http";
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { z } from "zod";
+
+const auditPath = process.env.DSH_E2E_MCP_AUDIT;
+if (!auditPath) throw new Error("DSH_E2E_MCP_AUDIT is required");
+
+async function record(tool, input) {
+  await appendFile(
+    auditPath,
+    `${JSON.stringify({ tool, input, observedAt: new Date().toISOString() })}\n`,
+    "utf8",
+  );
+}
+
+async function handleMcp(request, response) {
+  const mcp = new McpServer(
+    { name: "dsh-action-e2e", version: "1.0.0" },
+    { capabilities: { tools: {} } },
+  );
+  mcp.registerTool(
+    "echo",
+    {
+      description: "Return the supplied E2E marker unchanged.",
+      inputSchema: { marker: z.string().min(1).max(128) },
+    },
+    async ({ marker }) => {
+      await record("echo", { marker });
+      return { content: [{ type: "text", text: `DSH_E2E_MCP_ECHO:${marker}` }] };
+    },
+  );
+  mcp.registerTool(
+    "hidden",
+    { description: "A denied E2E control tool.", inputSchema: {} },
+    async () => {
+      await record("hidden", {});
+      return { content: [{ type: "text", text: "DSH_E2E_MCP_HIDDEN_EXECUTED" }] };
+    },
+  );
+
+  const transport = new StreamableHTTPServerTransport({});
+  response.on("close", () => {
+    void transport.close();
+    void mcp.close();
+  });
+  await mcp.connect(transport);
+  await transport.handleRequest(request, response);
+}
+
+const server = createServer((request, response) => {
+  if (request.method === "GET" && request.url === "/health") {
+    response.writeHead(200, { "content-type": "text/plain" }).end("ok\n");
+    return;
+  }
+  if (request.url !== "/mcp") {
+    response.writeHead(404).end();
+    return;
+  }
+  handleMcp(request, response).catch((error) => {
+    if (!response.headersSent) response.writeHead(500, { "content-type": "text/plain" });
+    response.end(error instanceof Error ? error.message : String(error));
+  });
+});
+
+server.listen(0, "0.0.0.0", () => {
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("Expected a TCP listener");
+  }
+  process.stdout.write(
+    `${JSON.stringify({
+      healthUrl: `http://127.0.0.1:${String(address.port)}/health`,
+      workerUrl: `http://host.docker.internal:${String(address.port)}/mcp`,
+    })}\n`,
+  );
+});
+
+function shutdown() {
+  server.close(() => process.exit(0));
+}
+process.once("SIGINT", shutdown);
+process.once("SIGTERM", shutdown);

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,1085 @@
+name: Core E2E
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_sha:
+        description: Full lowercase SHA of the candidate action commit
+        required: true
+        type: string
+      pull_request:
+        description: Open same-repository PR whose head is candidate_sha
+        required: true
+        type: number
+
+permissions: {}
+
+concurrency:
+  group: dsh-core-e2e-${{ github.repository }}-${{ inputs.pull_request }}
+  cancel-in-progress: false
+
+jobs:
+  gate:
+    name: Bind candidate to PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run_e2e: ${{ steps.bind.outputs.run_e2e }}
+      candidate_sha: ${{ steps.bind.outputs.candidate_sha }}
+      pull_request: ${{ steps.bind.outputs.pull_request }}
+      harness_sha: ${{ steps.bind.outputs.harness_sha }}
+    steps:
+      - name: Validate immutable candidate identity
+        id: bind
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          WORKFLOW_REF: ${{ github.ref }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+          DISPATCH_SHA: ${{ github.sha }}
+          ACTOR: ${{ github.actor }}
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          CANDIDATE_PR: ${{ inputs.pull_request }}
+          APPROVED_PR_SHA: ${{ vars.DSH_E2E_CANDIDATE_SHA }}
+        run: |
+          set -euo pipefail
+          sha_pattern='^[a-f0-9]{40}$'
+
+          [[ "$WORKFLOW_REF" == "refs/heads/$DEFAULT_BRANCH" ]] || {
+            echo "Core E2E must be dispatched from the default branch workflow" >&2
+            exit 1
+          }
+          [[ "$WORKFLOW_SHA" =~ $sha_pattern ]] || {
+            echo "The trusted workflow SHA must be a full lowercase commit SHA" >&2
+            exit 1
+          }
+          [[ "$DISPATCH_SHA" =~ $sha_pattern && "$DISPATCH_SHA" == "$WORKFLOW_SHA" ]] || {
+            echo "The dispatched commit must be the immutable workflow commit" >&2
+            exit 1
+          }
+          default_sha="$(gh api "repos/$REPOSITORY/git/ref/heads/$DEFAULT_BRANCH" --jq .object.sha)"
+          [[ "$DISPATCH_SHA" == "$default_sha" ]] || {
+            echo "The dispatch SHA must equal the live default-branch SHA" >&2
+            exit 1
+          }
+          [[ "$CANDIDATE_SHA" =~ $sha_pattern ]] || {
+            echo "candidate_sha must be a full lowercase commit SHA" >&2
+            exit 1
+          }
+          [[ "$CANDIDATE_PR" =~ ^[1-9][0-9]*$ ]] || {
+            echo "pull_request must be a positive integer" >&2
+            exit 1
+          }
+          [[ "$APPROVED_PR_SHA" =~ $sha_pattern && "$APPROVED_PR_SHA" == "$CANDIDATE_SHA" ]] || {
+            echo "DSH_E2E_CANDIDATE_SHA must exactly match candidate_sha" >&2
+            exit 1
+          }
+
+          pr_json="$(gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR")"
+          jq -e \
+            --arg sha "$CANDIDATE_SHA" \
+            --arg repo "${REPOSITORY,,}" \
+            --arg base "$DEFAULT_BRANCH" \
+            '(.state == "open") and (.draft == false) and
+             (.head.sha == $sha) and (.head.repo.full_name | ascii_downcase) == $repo and
+             (.base.repo.full_name | ascii_downcase) == $repo and (.base.ref == $base)' \
+            <<<"$pr_json" >/dev/null
+
+          permission="$(gh api "repos/$REPOSITORY/collaborators/$ACTOR/permission" --jq .permission 2>/dev/null || true)"
+          [[ "$permission" == "write" || "$permission" == "maintain" || "$permission" == "admin" ]] || {
+            echo "The triggering actor must have repository write permission" >&2
+            exit 1
+          }
+          echo "run_e2e=true" >> "$GITHUB_OUTPUT"
+          echo "candidate_sha=$CANDIDATE_SHA" >> "$GITHUB_OUTPUT"
+          echo "pull_request=$CANDIDATE_PR" >> "$GITHUB_OUTPUT"
+          echo "harness_sha=$DISPATCH_SHA" >> "$GITHUB_OUTPUT"
+          echo "Bound PR #$CANDIDATE_PR to candidate $CANDIDATE_SHA from the trusted default-branch workflow" >> "$GITHUB_STEP_SUMMARY"
+
+  read_only:
+    name: Read-only golden paths
+    needs: gate
+    if: needs.gate.outputs.run_e2e == 'true'
+    runs-on: ubuntu-latest
+    environment: core-e2e
+    timeout-minutes: 75
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout permanent harness
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.gate.outputs.harness_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout exact candidate
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.gate.outputs.candidate_sha }}
+          path: candidate-action
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Prepare immutable local harness
+        shell: bash
+        env:
+          HARNESS_SHA: ${{ needs.gate.outputs.harness_sha }}
+          CANDIDATE_SHA: ${{ needs.gate.outputs.candidate_sha }}
+          DEEPSEEK_SECRET_PRESENT: ${{ secrets.DEEPSEEK_API_KEY != '' }}
+        run: |
+          set -euo pipefail
+          [[ "$DEEPSEEK_SECRET_PRESENT" == "true" ]]
+          [[ "$(git rev-parse HEAD)" == "$HARNESS_SHA" ]]
+          [[ "$(git -C candidate-action rev-parse HEAD)" == "$CANDIDATE_SHA" ]]
+          ! git -C . config --local --get-regexp '^(http\..*\.extraheader|credential\.)' >/dev/null 2>&1
+          ! git -C candidate-action config --local --get-regexp '^(http\..*\.extraheader|credential\.)' >/dev/null 2>&1
+          node --check .github/e2e/mcp-http-server.mjs
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install fixture dependencies without lifecycle scripts
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
+      - name: Strict Profile and official Bundle baseline
+        id: strict
+        uses: ./candidate-action
+        with:
+          deepseek-api-key: ${{ secrets.DEEPSEEK_API_KEY }}
+          github-token: ${{ github.token }}
+          dsh-version: 0.1.1-rc.2
+          command: task
+          task-access: read
+          prompt: Inspect README.md and return one concise sentence describing this action. Do not request unavailable tools.
+          permission-profile: strict
+          progress-comment: "false"
+          max-turns: "2"
+          timeout-minutes: "12"
+
+      - name: Assert strict/Profile/Bundle result
+        shell: bash
+        env:
+          RESULT_JSON: ${{ steps.strict.outputs['result-json'] }}
+        run: |
+          set -euo pipefail
+          jq -e '
+            .schemaVersion == 1 and .conclusion == "success" and .operation == "task" and
+            .policy.trust == "trusted-read" and .permissions.profile == "strict" and
+            .permissions.effectiveTools == ["workspace.read","workspace.search"] and
+            .permissions.workspaceWrite == false and
+            .isolation.backend == "docker" and .isolation.processIsolated == true and
+            .isolation.workspaceAccess == "read-only" and
+            .isolation.extensionProfile == "github-action" and
+            (.isolation.extensionDigest | test("^[a-f0-9]{64}$")) and
+            .extensions.profile == "github-action" and
+            (.extensions.digest | test("^[a-f0-9]{64}$"))
+          ' <<<"$RESULT_JSON" >/dev/null
+
+      - name: Start real Streamable HTTP MCP fixture
+        id: mcp_server
+        shell: bash
+        run: |
+          set -euo pipefail
+          audit="$RUNNER_TEMP/dsh-e2e-mcp-audit.jsonl"
+          endpoint="$RUNNER_TEMP/dsh-e2e-mcp-endpoint.json"
+          : > "$audit"
+          DSH_E2E_MCP_AUDIT="$audit" node .github/e2e/mcp-http-server.mjs > "$endpoint" 2> "$RUNNER_TEMP/dsh-e2e-mcp.log" &
+          pid=$!
+          for _ in {1..60}; do
+            if [[ -s "$endpoint" ]] && curl --fail --silent "$(jq -r .healthUrl "$endpoint")" >/dev/null; then break; fi
+            kill -0 "$pid" 2>/dev/null || { cat "$RUNNER_TEMP/dsh-e2e-mcp.log" >&2; exit 1; }
+            sleep 1
+          done
+          curl --fail --silent "$(jq -r .healthUrl "$endpoint")" >/dev/null
+          echo "pid=$pid" >> "$GITHUB_OUTPUT"
+          echo "audit=$audit" >> "$GITHUB_OUTPUT"
+          echo "worker_url=$(jq -r .workerUrl "$endpoint")" >> "$GITHUB_OUTPUT"
+
+      - name: MCP allow and deny
+        id: mcp
+        uses: ./candidate-action
+        with:
+          deepseek-api-key: ${{ secrets.DEEPSEEK_API_KEY }}
+          github-token: ${{ github.token }}
+          dsh-version: 0.1.1-rc.2
+          command: task
+          task-access: read
+          prompt: Call the available MCP echo tool exactly once with marker rc2-mcp-allow. Never call hidden or any other tool. Report the returned text.
+          permission-profile: custom
+          allowed-tools: '["workspace.read","workspace.search","mcp.fixture.echo","mcp.fixture.hidden"]'
+          disallowed-tools: '["mcp.fixture.hidden"]'
+          mcp-config: >-
+            {"schemaVersion":1,"servers":[{"id":"fixture","transport":"streamable-http","url":"${{ steps.mcp_server.outputs.worker_url }}","headers":{},"network":true,"maxCalls":2,"reconnect":{"enabled":false,"initialDelayMs":500,"maxDelayMs":1000,"maxAttempts":1},"tools":[{"id":"echo","name":"echo","description":"Return the supplied E2E marker.","permissions":["read","network"],"timeoutMs":15000,"maxOutputBytes":16384,"maxCalls":1},{"id":"hidden","name":"hidden","description":"Denied control tool.","permissions":["read","network"],"timeoutMs":15000,"maxOutputBytes":16384,"maxCalls":1}]}]}
+          progress-comment: "false"
+          max-turns: "2"
+          timeout-minutes: "12"
+
+      - name: Assert MCP allow/deny and receipts
+        shell: bash
+        env:
+          RESULT_JSON: ${{ steps.mcp.outputs['result-json'] }}
+          MCP_AUDIT: ${{ steps.mcp_server.outputs.audit }}
+        run: |
+          set -euo pipefail
+          jq -e '
+            .conclusion == "success" and .permissions.profile == "custom" and
+            .permissions.effectiveTools == ["mcp.fixture.echo","workspace.read","workspace.search"] and
+            .permissions.network == "bridge" and
+            (.permissions.deniedTools | any(.id == "mcp.fixture.hidden")) and
+            (.permissions.trustedExtensions | any(.id == "fixture" and .kind == "mcp" and .network == true)) and
+            (.loop.dshToolReceipts | map(select(.id == "mcp.fixture.echo" and .provider == "mcp" and .completed == true and .ok == true)) | length == 1) and
+            (.loop.dshToolReceipts | all(.id != "mcp.fixture.hidden"))
+          ' <<<"$RESULT_JSON" >/dev/null
+          [[ "$(wc -l < "$MCP_AUDIT")" -eq 1 ]]
+          jq -e '.tool == "echo" and .input.marker == "rc2-mcp-allow"' "$MCP_AUDIT" >/dev/null
+          ! grep -q 'hidden' "$MCP_AUDIT"
+
+      - name: Stop MCP fixture
+        if: always()
+        shell: bash
+        env:
+          MCP_PID: ${{ steps.mcp_server.outputs.pid }}
+        run: |
+          if [[ "$MCP_PID" =~ ^[1-9][0-9]*$ ]]; then
+            kill -TERM "$MCP_PID" 2>/dev/null || true
+            wait "$MCP_PID" 2>/dev/null || true
+          fi
+
+      - name: Real mediated Web Search
+        id: web
+        uses: ./candidate-action
+        with:
+          deepseek-api-key: ${{ secrets.DEEPSEEK_API_KEY }}
+          github-token: ${{ github.token }}
+          dsh-version: 0.1.1-rc.2
+          command: task
+          task-access: read
+          prompt: Use the web search tool exactly once to find the official DeepSeek Harness repository, then report the repository name and stop.
+          permission-profile: custom
+          allowed-tools: '["native.web-search"]'
+          progress-comment: "false"
+          max-turns: "2"
+          timeout-minutes: "12"
+
+      - name: Assert Web Search mediation and receipt
+        shell: bash
+        env:
+          RESULT_JSON: ${{ steps.web.outputs['result-json'] }}
+        run: |
+          set -euo pipefail
+          jq -e '
+            .conclusion == "success" and
+            .permissions.effectiveTools == ["native.web-search"] and
+            .permissions.network == "mediated-web" and
+            (.loop.dshToolReceipts | map(select(.id == "native.web-search" and .completed == true and .ok == true)) | length == 1)
+          ' <<<"$RESULT_JSON" >/dev/null
+
+      - name: Revalidate candidate PR identity
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          CANDIDATE_SHA: ${{ needs.gate.outputs.candidate_sha }}
+          CANDIDATE_PR: ${{ needs.gate.outputs.pull_request }}
+        run: |
+          set -euo pipefail
+          pr_json="$(gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR")"
+          jq -e --arg sha "$CANDIDATE_SHA" --arg repo "${REPOSITORY,,}" --arg base "$DEFAULT_BRANCH" '
+            .state == "open" and .draft == false and .head.sha == $sha and
+            (.head.repo.full_name | ascii_downcase) == $repo and
+            (.base.repo.full_name | ascii_downcase) == $repo and .base.ref == $base
+          ' <<<"$pr_json" >/dev/null
+
+  write:
+    name: Write guards and golden paths
+    needs: gate
+    if: needs.gate.outputs.run_e2e == 'true'
+    runs-on: ubuntu-latest
+    environment: core-e2e
+    timeout-minutes: 120
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout permanent harness
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.gate.outputs.harness_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout exact candidate
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.gate.outputs.candidate_sha }}
+          path: candidate-action
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+
+      - name: Prepare write mutation baseline
+        id: baseline
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          HARNESS_SHA: ${{ needs.gate.outputs.harness_sha }}
+          CANDIDATE_SHA: ${{ needs.gate.outputs.candidate_sha }}
+          CANDIDATE_PR: ${{ needs.gate.outputs.pull_request }}
+          DEEPSEEK_SECRET_PRESENT: ${{ secrets.DEEPSEEK_API_KEY != '' }}
+        run: |
+          set -euo pipefail
+          [[ "$DEEPSEEK_SECRET_PRESENT" == "true" ]]
+          [[ "$(git rev-parse HEAD)" == "$HARNESS_SHA" ]]
+          [[ "$(git -C candidate-action rev-parse HEAD)" == "$CANDIDATE_SHA" ]]
+          ! git -C . config --local --get-regexp '^(http\..*\.extraheader|credential\.)' >/dev/null 2>&1
+          ! git -C candidate-action config --local --get-regexp '^(http\..*\.extraheader|credential\.)' >/dev/null 2>&1
+          cat > "$RUNNER_TEMP/dsh-e2e-snapshot.sh" <<'SNAPSHOT'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          export LC_ALL=C
+          prefix="$1"
+          : "${REPOSITORY:?}" "${DEFAULT_BRANCH:?}" "${CANDIDATE_PR:?}"
+          gh api "repos/$REPOSITORY/git/ref/heads/$DEFAULT_BRANCH" --jq .object.sha > "$prefix.main"
+          gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR" | jq -cS '{
+            number,state,draft,
+            head:{repo:.head.repo.full_name,ref:.head.ref,sha:.head.sha},
+            base:{repo:.base.repo.full_name,ref:.base.ref,sha:.base.sha},
+            body:(.body // "")
+          }' > "$prefix.candidate"
+          gh api --paginate "repos/$REPOSITORY/pulls?state=all&per_page=100" \
+            --jq '.[].number' | sort -n > "$prefix.prs"
+          gh api --paginate "repos/$REPOSITORY/issues/$CANDIDATE_PR/comments?per_page=100" \
+            --jq '.[] | {id,userId:.user.id,updatedAt:.updated_at,body}' \
+            | jq -cS . | sort > "$prefix.comments"
+          gh api --paginate "repos/$REPOSITORY/git/matching-refs/heads/dsh/task-?per_page=100" \
+            --jq '.[] | [.ref,.object.type,.object.sha] | @tsv' | sort > "$prefix.task-refs"
+          gh api --paginate "repos/$REPOSITORY/pulls?state=all&per_page=100" --jq '
+            .[] |
+            select(
+              ((.head.ref // "") | startswith("dsh/task-")) or
+              ((.body // "") | contains("<!-- dsh-action:task:v1 "))
+            ) |
+            {
+              number,state,draft,
+              head:{repo:.head.repo.full_name,ref:.head.ref,sha:.head.sha},
+              base:{repo:.base.repo.full_name,ref:.base.ref,sha:.base.sha},
+              bodyMarker:((.body // "") | contains("<!-- dsh-action:task:v1 ")),
+              body:(.body // "")
+            }
+          ' | jq -cS . | sort > "$prefix.task-prs"
+          SNAPSHOT
+          chmod 700 "$RUNNER_TEMP/dsh-e2e-snapshot.sh"
+
+          prefix="$RUNNER_TEMP/dsh-e2e-baseline"
+          "$RUNNER_TEMP/dsh-e2e-snapshot.sh" "$prefix"
+          pr_json="$(gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR")"
+          jq -e --arg sha "$CANDIDATE_SHA" --arg repo "${REPOSITORY,,}" --arg base "$DEFAULT_BRANCH" '
+            .state == "open" and .draft == false and .head.sha == $sha and
+            (.head.repo.full_name | ascii_downcase) == $repo and
+            (.base.repo.full_name | ascii_downcase) == $repo and .base.ref == $base
+          ' <<<"$pr_json" >/dev/null
+          echo "main_sha=$(cat "$prefix.main")" >> "$GITHUB_OUTPUT"
+
+      - name: Validation Integrity blocks weakened entrypoint
+        id: integrity
+        continue-on-error: true
+        uses: ./candidate-action
+        with:
+          deepseek-api-key: ${{ secrets.DEEPSEEK_API_KEY }}
+          github-token: ${{ github.token }}
+          dsh-version: 0.1.1-rc.2
+          command: task
+          task-access: write
+          allow-write: "true"
+          prompt: Use native.bash exactly once to replace scripts/verify-dsh-config.mjs with the single line process.exit(0). Make no other change and do not restore it.
+          permission-profile: standard
+          progress-comment: "false"
+          validation-integrity: strict
+          run-tests: "true"
+          test-commands: '[["node","scripts/verify-dsh-config.mjs"]]'
+          max-turns: "2"
+          timeout-minutes: "15"
+
+      - name: Assert integrity failure
+        shell: bash
+        env:
+          RESULT_JSON: ${{ steps.integrity.outputs['result-json'] }}
+          EXPECTED_FAILURE: ${{ steps.integrity.outcome == 'failure' }}
+        run: |
+          set -euo pipefail
+          [[ "$EXPECTED_FAILURE" == "true" ]]
+          jq -e '
+            .conclusion == "failure" and .status == "validation_failed" and
+            .error.code == "VALIDATION_INTEGRITY" and .error.phase == "validation" and
+            .validation.status == "failed" and
+            .validation.integrity.mode == "strict" and
+            .validation.integrity.dangerousChangeCount >= 1 and
+            (.loop.dshToolReceipts | any(.id == "native.bash" and .completed == true and .ok == true))
+          ' <<<"$RESULT_JSON" >/dev/null
+
+      - name: Assert expected failures made no GitHub mutation
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          CANDIDATE_PR: ${{ needs.gate.outputs.pull_request }}
+        run: |
+          set -euo pipefail
+          prefix="$RUNNER_TEMP/dsh-e2e-baseline"
+          current="$RUNNER_TEMP/dsh-e2e-current-integrity"
+          "$RUNNER_TEMP/dsh-e2e-snapshot.sh" "$current"
+          for component in main candidate prs comments task-refs task-prs; do
+            cmp "$prefix.$component" "$current.$component"
+          done
+
+      - name: Ordinary validation failure
+        id: validation
+        continue-on-error: true
+        uses: ./candidate-action
+        with:
+          deepseek-api-key: ${{ secrets.DEEPSEEK_API_KEY }}
+          github-token: ${{ github.token }}
+          dsh-version: 0.1.1-rc.2
+          command: task
+          task-access: write
+          allow-write: "true"
+          prompt: Request command.prepare-validation exactly once. After the fixed Controller command succeeds, finalize without calling native.bash or changing anything else.
+          permission-profile: standard
+          allowed-tools: '["command.prepare-validation"]'
+          disallowed-tools: '["native.bash","native.web-search","native.subagent"]'
+          tool-config: >-
+            {"schemaVersion":1,"commands":[{"name":"prepare-validation","description":"Create the ordinary validation-failure marker.","argv":["node","-e","require('node:fs').writeFileSync('dsh-e2e-validation-${{ github.run_id }}-${{ github.run_attempt }}.txt','validation-failure\\n')"],"timeoutMinutes":1,"maxOutputBytes":16384,"maxCalls":1,"network":"none","workspaceAccess":"write"}]}
+          progress-comment: "false"
+          validation-integrity: strict
+          run-tests: "true"
+          test-commands: '[["node","-e","process.exit(23)"]]'
+          max-turns: "2"
+          timeout-minutes: "15"
+
+      - name: Assert ordinary validation failure and no mutation
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          CANDIDATE_PR: ${{ needs.gate.outputs.pull_request }}
+          RESULT_JSON: ${{ steps.validation.outputs['result-json'] }}
+          EXPECTED_FAILURE: ${{ steps.validation.outcome == 'failure' }}
+        run: |
+          set -euo pipefail
+          [[ "$EXPECTED_FAILURE" == "true" ]]
+          jq -e '
+            .conclusion == "failure" and .status == "validation_failed" and
+            .error.code == "VALIDATION_FAILED" and .error.phase == "validation" and
+            .validation.status == "failed" and
+            (.loop.toolReceipts | any(.id == "command.prepare-validation" and .ok == true)) and
+            (.loop.dshToolReceipts // [] | all(.id != "native.bash"))
+          ' <<<"$RESULT_JSON" >/dev/null
+          prefix="$RUNNER_TEMP/dsh-e2e-baseline"
+          current="$RUNNER_TEMP/dsh-e2e-current-validation"
+          "$RUNNER_TEMP/dsh-e2e-snapshot.sh" "$current"
+          for component in main candidate prs comments task-refs task-prs; do
+            cmp "$prefix.$component" "$current.$component"
+          done
+
+      - name: Real native.subagent with no-change write
+        id: no_change
+        uses: ./candidate-action
+        with:
+          deepseek-api-key: ${{ secrets.DEEPSEEK_API_KEY }}
+          github-token: ${{ github.token }}
+          dsh-version: 0.1.1-rc.2
+          command: task
+          task-access: write
+          allow-write: "true"
+          prompt: Call native.subagent exactly once for a read-only inspection of README.md. After it returns, make no workspace changes, call no other tool, and summarize its answer.
+          permission-profile: custom
+          allowed-tools: '["workspace.read","workspace.search","workspace.edit","native.subagent"]'
+          disallowed-tools: '["native.bash","native.web-search"]'
+          progress-comment: "false"
+          run-tests: "true"
+          test-commands: "[]"
+          max-turns: "2"
+          timeout-minutes: "15"
+
+      - name: Assert native.subagent and no-change semantics
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          CANDIDATE_PR: ${{ needs.gate.outputs.pull_request }}
+          RESULT_JSON: ${{ steps.no_change.outputs['result-json'] }}
+        run: |
+          set -euo pipefail
+          jq -e '
+            .conclusion == "success" and .policy.trust == "trusted-write" and
+            .write.status == "no-changes" and .write.changedPaths == [] and
+            .validation.status == "not-applicable" and
+            (.loop.dshToolReceipts | map(select(.id == "native.subagent" and .completed == true and .ok == true)) | length == 1) and
+            (.loop.dshToolReceipts | all(.id != "native.bash" and .id != "native.web-search"))
+          ' <<<"$RESULT_JSON" >/dev/null
+          prefix="$RUNNER_TEMP/dsh-e2e-baseline"
+          current="$RUNNER_TEMP/dsh-e2e-current-no-change"
+          "$RUNNER_TEMP/dsh-e2e-snapshot.sh" "$current"
+          for component in main candidate prs comments task-refs task-prs; do
+            cmp "$prefix.$component" "$current.$component"
+          done
+
+      - name: Trusted standard Bash write
+        id: trusted
+        uses: ./candidate-action
+        with:
+          deepseek-api-key: ${{ secrets.DEEPSEEK_API_KEY }}
+          github-token: ${{ github.token }}
+          dsh-version: 0.1.1-rc.2
+          command: task
+          task-access: write
+          allow-write: "true"
+          prompt: Use native.bash exactly once to create dsh-e2e-write-${{ github.run_id }}-${{ github.run_attempt }}.txt containing exactly trusted-write followed by a newline. Make no other change.
+          permission-profile: standard
+          disallowed-tools: '["native.web-search","native.subagent"]'
+          progress-comment: "false"
+          validation-integrity: strict
+          run-tests: "true"
+          test-commands: '[["node","-e","const fs=require(\"node:fs\");if(fs.readFileSync(process.argv[1],\"utf8\")!==\"trusted-write\\n\")process.exit(1)","dsh-e2e-write-${{ github.run_id }}-${{ github.run_attempt }}.txt"]]'
+          max-turns: "2"
+          timeout-minutes: "18"
+
+      - name: Verify trusted write PR identity
+        id: verify_write
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          CANDIDATE_SHA: ${{ needs.gate.outputs.candidate_sha }}
+          CANDIDATE_PR: ${{ needs.gate.outputs.pull_request }}
+          RESULT_JSON: ${{ steps.trusted.outputs['result-json'] }}
+          FILE_PATH: dsh-e2e-write-${{ github.run_id }}-${{ github.run_attempt }}.txt
+        run: |
+          set -euo pipefail
+          jq -e --arg path "$FILE_PATH" '
+            .conclusion == "success" and .policy.trust == "trusted-write" and
+            .validation.status == "passed" and .validation.integrity.mode == "strict" and
+            .write.status == "success" and
+            (.write.branchName | test("^dsh/task-[a-f0-9]{24}$")) and
+            (.write.pullRequestNumber | type == "number") and
+            (.loop.dshToolReceipts | any(.id == "native.bash" and .completed == true and .ok == true))
+          ' <<<"$RESULT_JSON" >/dev/null
+
+          branch="$(jq -r .write.branchName <<<"$RESULT_JSON")"
+          pull="$(jq -r .write.pullRequestNumber <<<"$RESULT_JSON")"
+          [[ "$branch" =~ ^dsh/task-[a-f0-9]{24}$ ]]
+          [[ "$pull" =~ ^[1-9][0-9]*$ ]]
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "pull=$pull" >> "$GITHUB_OUTPUT"
+          operation="${branch#dsh/task-}"
+          pr_json="$(gh api "repos/$REPOSITORY/pulls/$pull")"
+          head_sha="$(jq -r .head.sha <<<"$pr_json")"
+          base_sha="$(cat "$RUNNER_TEMP/dsh-e2e-baseline.main")"
+          jq -e --arg repo "${REPOSITORY,,}" --arg base "$DEFAULT_BRANCH" --arg branch "$branch" '
+            .state == "open" and (.head.repo.full_name | ascii_downcase) == $repo and
+            (.base.repo.full_name | ascii_downcase) == $repo and
+            .head.ref == $branch and .base.ref == $base
+          ' <<<"$pr_json" >/dev/null
+          grep -Eq "<!-- dsh-action:task:v1 operation=$operation snapshot=[a-f0-9]{24} -->" <<<"$(jq -r .body <<<"$pr_json")"
+          commit_json="$(gh api "repos/$REPOSITORY/git/commits/$head_sha")"
+          [[ "$(jq -r '.parents | length' <<<"$commit_json")" -eq 1 ]]
+          [[ "$(jq -r '.parents[0].sha' <<<"$commit_json")" == "$base_sha" ]]
+          grep -Fxq "DSH-Task-Key: $operation" <<<"$(jq -r .message <<<"$commit_json")"
+          [[ "$(gh api "repos/$REPOSITORY/git/ref/heads/$branch" --jq .object.sha)" == "$head_sha" ]]
+          gh api "repos/$REPOSITORY/compare/$base_sha...$head_sha" \
+            | jq -e --arg path "$FILE_PATH" '.files | length == 1 and .[0].filename == $path and .[0].status == "added"' >/dev/null
+          content="$(gh api "repos/$REPOSITORY/contents/$FILE_PATH?ref=$head_sha" --jq .content | tr -d '\n' | base64 --decode)"
+          [[ "$content" == "trusted-write" ]]
+          candidate_json="$(gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR")"
+          jq -e --arg sha "$CANDIDATE_SHA" --arg repo "${REPOSITORY,,}" --arg base "$DEFAULT_BRANCH" '
+            .state == "open" and .draft == false and .head.sha == $sha and
+            (.head.repo.full_name | ascii_downcase) == $repo and
+            (.base.repo.full_name | ascii_downcase) == $repo and .base.ref == $base
+          ' <<<"$candidate_json" >/dev/null
+
+      - name: Close only the verified E2E PR and delete its branch
+        if: always()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          BRANCH: ${{ steps.verify_write.outputs.branch }}
+          PULL: ${{ steps.verify_write.outputs.pull }}
+          RESULT_JSON: ${{ steps.trusted.outputs['result-json'] }}
+          BASE_SHA: ${{ steps.baseline.outputs.main_sha }}
+          FILE_PATH: dsh-e2e-write-${{ github.run_id }}-${{ github.run_attempt }}.txt
+        run: |
+          set -euo pipefail
+          branch="$BRANCH"
+          pull="$PULL"
+          if [[ ! "$branch" =~ ^dsh/task-[a-f0-9]{24}$ ]] || [[ ! "$pull" =~ ^[1-9][0-9]*$ ]]; then
+            if jq -e '
+              (.write.branchName | type == "string" and test("^dsh/task-[a-f0-9]{24}$")) and
+              (.write.pullRequestNumber | type == "number" and . >= 1 and floor == .)
+            ' <<<"$RESULT_JSON" >/dev/null 2>&1; then
+              branch="$(jq -r .write.branchName <<<"$RESULT_JSON")"
+              pull="$(jq -r .write.pullRequestNumber <<<"$RESULT_JSON")"
+            else
+              echo "::warning::Could not recover a verified E2E branch/PR identity from the trusted-write result; inspect run $GITHUB_RUN_ID for a dsh/task-* PR containing $FILE_PATH. No broad cleanup was attempted."
+              {
+                echo "### E2E cleanup requires inspection"
+                echo
+                echo "The trusted-write result did not expose a strictly valid branch and PR number. Inspect this run for a same-repository \`dsh/task-*\` PR whose only added file is \`$FILE_PATH\`. The harness deliberately did not delete any unverified ref."
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+          fi
+          [[ "$branch" =~ ^dsh/task-[a-f0-9]{24}$ ]] || exit 1
+          [[ "$pull" =~ ^[1-9][0-9]*$ ]] || exit 1
+          operation="${branch#dsh/task-}"
+          pr_json="$(gh api "repos/$REPOSITORY/pulls/$pull")"
+          head_sha="$(jq -r .head.sha <<<"$pr_json")"
+          jq -e --arg repo "${REPOSITORY,,}" --arg base "$DEFAULT_BRANCH" --arg branch "$branch" '
+            .state == "open" and (.head.repo.full_name | ascii_downcase) == $repo and
+            (.base.repo.full_name | ascii_downcase) == $repo and
+            .head.ref == $branch and .base.ref == $base
+          ' <<<"$pr_json" >/dev/null
+          grep -Eq "<!-- dsh-action:task:v1 operation=$operation snapshot=[a-f0-9]{24} -->" <<<"$(jq -r .body <<<"$pr_json")"
+          commit_json="$(gh api "repos/$REPOSITORY/git/commits/$head_sha")"
+          [[ "$(jq -r '.parents | length' <<<"$commit_json")" -eq 1 ]]
+          [[ "$(jq -r '.parents[0].sha' <<<"$commit_json")" == "$BASE_SHA" ]]
+          grep -Fxq "DSH-Task-Key: $operation" <<<"$(jq -r .message <<<"$commit_json")"
+          [[ "$(gh api "repos/$REPOSITORY/git/ref/heads/$branch" --jq .object.sha)" == "$head_sha" ]]
+          gh api "repos/$REPOSITORY/compare/$BASE_SHA...$head_sha" \
+            | jq -e --arg path "$FILE_PATH" '.files | length == 1 and .[0].filename == $path and .[0].status == "added"' >/dev/null
+          content="$(gh api "repos/$REPOSITORY/contents/$FILE_PATH?ref=$head_sha" --jq .content | tr -d '\n' | base64 --decode)"
+          [[ "$content" == "trusted-write" ]]
+          gh api --method PATCH "repos/$REPOSITORY/pulls/$pull" -f state=closed >/dev/null
+          gh api --method DELETE "repos/$REPOSITORY/git/refs/heads/$branch"
+          [[ "$(gh api "repos/$REPOSITORY/pulls/$pull" --jq .state)" == "closed" ]]
+          if gh api "repos/$REPOSITORY/git/ref/heads/$branch" >/dev/null 2>&1; then
+            echo "Verified E2E branch still exists after cleanup" >&2
+            exit 1
+          fi
+
+      - name: Revalidate candidate PR identity and credential-free checkout
+        if: always()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          CANDIDATE_SHA: ${{ needs.gate.outputs.candidate_sha }}
+          CANDIDATE_PR: ${{ needs.gate.outputs.pull_request }}
+        run: |
+          set -euo pipefail
+          pr_json="$(gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR")"
+          jq -e --arg sha "$CANDIDATE_SHA" --arg repo "${REPOSITORY,,}" --arg base "$DEFAULT_BRANCH" '
+            .state == "open" and .draft == false and .head.sha == $sha and
+            (.head.repo.full_name | ascii_downcase) == $repo and
+            (.base.repo.full_name | ascii_downcase) == $repo and .base.ref == $base
+          ' <<<"$pr_json" >/dev/null
+          ! git -C . config --local --get-regexp '^(http\..*\.extraheader|credential\.)' >/dev/null 2>&1
+          ! git -C candidate-action config --local --get-regexp '^(http\..*\.extraheader|credential\.)' >/dev/null 2>&1
+
+  cancellation:
+    name: Best-effort cancellation finalization
+    needs: [gate, read_only, write]
+    if: needs.gate.outputs.run_e2e == 'true'
+    runs-on: ubuntu-latest
+    environment: core-e2e
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
+    steps:
+      - name: Checkout permanent harness
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.gate.outputs.harness_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout exact candidate
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.gate.outputs.candidate_sha }}
+          path: candidate-action
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+
+      - name: Prepare cancellation baseline and fixture
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          HARNESS_SHA: ${{ needs.gate.outputs.harness_sha }}
+          CANDIDATE_SHA: ${{ needs.gate.outputs.candidate_sha }}
+          CANDIDATE_PR: ${{ needs.gate.outputs.pull_request }}
+          DEEPSEEK_SECRET_PRESENT: ${{ secrets.DEEPSEEK_API_KEY != '' }}
+        run: |
+          set -euo pipefail
+          export LC_ALL=C
+          [[ "$DEEPSEEK_SECRET_PRESENT" == "true" ]]
+          [[ "$(git rev-parse HEAD)" == "$HARNESS_SHA" ]]
+          [[ "$(git -C candidate-action rev-parse HEAD)" == "$CANDIDATE_SHA" ]]
+          ! git -C . config --local --get-regexp '^(http\..*\.extraheader|credential\.)' >/dev/null 2>&1
+          ! git -C candidate-action config --local --get-regexp '^(http\..*\.extraheader|credential\.)' >/dev/null 2>&1
+          node --check .github/e2e/hanging-http-server.mjs
+
+          pr_json="$(gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR")"
+          jq -e --arg sha "$CANDIDATE_SHA" --arg repo "${REPOSITORY,,}" --arg base "$DEFAULT_BRANCH" '
+            .state == "open" and .draft == false and .head.sha == $sha and
+            (.head.repo.full_name | ascii_downcase) == $repo and
+            (.base.repo.full_name | ascii_downcase) == $repo and .base.ref == $base
+          ' <<<"$pr_json" >/dev/null
+
+          prefix="$RUNNER_TEMP/dsh-e2e-cancel-baseline"
+          gh api "repos/$REPOSITORY/git/ref/heads/$DEFAULT_BRANCH" --jq .object.sha > "$prefix.main"
+          jq -cS '{
+            number,state,draft,
+            head:{repo:.head.repo.full_name,ref:.head.ref,sha:.head.sha},
+            base:{repo:.base.repo.full_name,ref:.base.ref,sha:.base.sha},
+            body:(.body // "")
+          }' <<<"$pr_json" > "$prefix.candidate"
+          gh api --paginate "repos/$REPOSITORY/issues/$CANDIDATE_PR/comments?per_page=100" \
+            --jq '.[] | {id,userId:.user.id,updatedAt:.updated_at,body}' \
+            | jq -cS . | sort > "$prefix.comments"
+          gh api --paginate "repos/$REPOSITORY/git/matching-refs/heads/dsh/task-?per_page=100" \
+            --jq '.[] | [.ref,.object.type,.object.sha] | @tsv' | sort > "$prefix.task-refs"
+          gh api --paginate "repos/$REPOSITORY/pulls?state=all&per_page=100" --jq '
+            .[] |
+            select(
+              ((.head.ref // "") | startswith("dsh/task-")) or
+              ((.body // "") | contains("<!-- dsh-action:task:v1 "))
+            ) |
+            {
+              number,state,draft,
+              head:{repo:.head.repo.full_name,ref:.head.ref,sha:.head.sha},
+              base:{repo:.base.repo.full_name,ref:.base.ref,sha:.base.sha},
+              bodyMarker:((.body // "") | contains("<!-- dsh-action:task:v1 ")),
+              body:(.body // "")
+            }
+          ' | jq -cS . | sort > "$prefix.task-prs"
+
+      - name: Create dedicated cancellation issue
+        id: cancel_issue
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          CANDIDATE_SHA: ${{ needs.gate.outputs.candidate_sha }}
+        run: |
+          set -euo pipefail
+          marker="<!-- dsh-e2e:cancellation:v1 run=$GITHUB_RUN_ID attempt=$GITHUB_RUN_ATTEMPT candidate=$CANDIDATE_SHA -->"
+          title="DSH E2E cancellation $GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT"
+          body="$(printf '%s\n\n%s' "$marker" "Temporary issue owned by the trusted Core E2E cancellation harness.")"
+          issue_json="$(gh api --method POST "repos/$REPOSITORY/issues" -f title="$title" -f body="$body")"
+          issue_number="$(jq -r .number <<<"$issue_json")"
+          issue_id="$(jq -r .id <<<"$issue_json")"
+          echo "number=$issue_number" >> "$GITHUB_OUTPUT"
+          echo "id=$issue_id" >> "$GITHUB_OUTPUT"
+          jq -e --argjson number "$issue_number" --argjson id "$issue_id" \
+            --arg title "$title" --arg body "$body" '
+            .number == $number and .id == $id and .state == "open" and
+            (.draft // false) == false and (has("pull_request") | not) and
+            .user.id == 41898282 and .title == $title and .body == $body
+          ' <<<"$issue_json" >/dev/null
+
+      - name: Exercise graceful SIGTERM and isolated sticky transition
+        id: cancel_transition
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          REPOSITORY: ${{ github.repository }}
+          CANDIDATE_SHA: ${{ needs.gate.outputs.candidate_sha }}
+          ISSUE_NUMBER: ${{ steps.cancel_issue.outputs.number }}
+          ISSUE_ID: ${{ steps.cancel_issue.outputs.id }}
+        run: |
+          set -euo pipefail
+          [[ "$ISSUE_NUMBER" =~ ^[1-9][0-9]*$ ]]
+          [[ "$ISSUE_ID" =~ ^[1-9][0-9]*$ ]]
+
+          fixture_json="$RUNNER_TEMP/dsh-e2e-hanging.json"
+          node .github/e2e/hanging-http-server.mjs > "$fixture_json" 2> "$RUNNER_TEMP/dsh-e2e-hanging.log" &
+          fixture_pid=$!
+          action_pid=""
+          cleanup_processes() {
+            if [[ "$action_pid" =~ ^[1-9][0-9]*$ ]] && kill -0 "$action_pid" 2>/dev/null; then
+              kill -KILL "$action_pid" 2>/dev/null || true
+            fi
+            kill -TERM "$fixture_pid" 2>/dev/null || true
+          }
+          trap cleanup_processes EXIT
+          for _ in {1..30}; do
+            if [[ -s "$fixture_json" ]] && curl --fail --silent "$(jq -r .healthUrl "$fixture_json")" >/dev/null; then break; fi
+            kill -0 "$fixture_pid" 2>/dev/null || { cat "$RUNNER_TEMP/dsh-e2e-hanging.log" >&2; exit 1; }
+            sleep 1
+          done
+          base_url="$(jq -r .baseUrl "$fixture_json")"
+
+          gh api "repos/$REPOSITORY" > "$RUNNER_TEMP/dsh-e2e-repository.json"
+          issue_json="$(gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER")"
+          marker="<!-- dsh-e2e:cancellation:v1 run=$GITHUB_RUN_ID attempt=$GITHUB_RUN_ATTEMPT candidate=$CANDIDATE_SHA -->"
+          jq -e --argjson number "$ISSUE_NUMBER" --argjson id "$ISSUE_ID" --arg marker "$marker" '
+            .number == $number and .id == $id and .state == "open" and
+            (has("pull_request") | not) and .user.id == 41898282 and
+            (.body | contains($marker))
+          ' <<<"$issue_json" >/dev/null
+          jq -n \
+            --slurpfile repository "$RUNNER_TEMP/dsh-e2e-repository.json" \
+            --argjson issue "$issue_json" \
+            --arg actor "$GITHUB_ACTOR" \
+            '{action:"opened",repository:$repository[0],sender:{login:$actor},issue:$issue}' \
+            > "$RUNNER_TEMP/dsh-e2e-cancel-event.json"
+          : > "$RUNNER_TEMP/dsh-e2e-cancel-output"
+          : > "$RUNNER_TEMP/dsh-e2e-cancel-summary"
+          run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+
+          set +e
+          env \
+            "INPUT_DEEPSEEK-API-KEY=$DEEPSEEK_API_KEY" \
+            "INPUT_GITHUB-TOKEN=$GH_TOKEN" \
+            'INPUT_DSH-VERSION=0.1.1-rc.2' \
+            'INPUT_COMMAND=task' \
+            'INPUT_TASK-ACCESS=read' \
+            'INPUT_PROMPT=Wait for the upstream response and do not finish early.' \
+            'INPUT_PERMISSION-PROFILE=strict' \
+            'INPUT_PROGRESS-COMMENT=true' \
+            'INPUT_MAX-TURNS=2' \
+            'INPUT_TIMEOUT-MINUTES=15' \
+            "INPUT_BASE-URL=$base_url" \
+            GITHUB_EVENT_NAME=issues \
+            GITHUB_EVENT_PATH="$RUNNER_TEMP/dsh-e2e-cancel-event.json" \
+            GITHUB_OUTPUT="$RUNNER_TEMP/dsh-e2e-cancel-output" \
+            GITHUB_STEP_SUMMARY="$RUNNER_TEMP/dsh-e2e-cancel-summary" \
+            node candidate-action/dist/index.js > "$RUNNER_TEMP/dsh-e2e-cancel.log" 2>&1 &
+          action_pid=$!
+          set -e
+
+          comment_id=""
+          for _ in {1..180}; do
+            if ! kill -0 "$action_pid" 2>/dev/null; then
+              cat "$RUNNER_TEMP/dsh-e2e-cancel.log" >&2
+              echo "Candidate exited before the cancellable progress state was observed" >&2
+              exit 1
+            fi
+            mapfile -t matches < <(
+              gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100" \
+                --jq ".[] | select(.user.id == 41898282 and (.body | contains(\"$run_url\")) and (.body | contains(\"In progress\"))) | .id"
+            )
+            [[ "${#matches[@]}" -le 1 ]]
+            if [[ "${#matches[@]}" -eq 1 ]]; then
+              comment_id="${matches[0]}"
+              [[ "$(gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100" --jq 'length')" -eq 1 ]]
+              break
+            fi
+            sleep 1
+          done
+          [[ "$comment_id" =~ ^[1-9][0-9]*$ ]]
+          echo "comment_id=$comment_id" >> "$GITHUB_OUTPUT"
+          initial_comment="$(gh api "repos/$REPOSITORY/issues/comments/$comment_id")"
+          jq -e --arg run "$run_url" '
+            .user.id == 41898282 and (.body | contains($run)) and (.body | contains("In progress"))
+          ' <<<"$initial_comment" >/dev/null
+
+          kill -TERM "$action_pid"
+          stopped=false
+          for _ in {1..90}; do
+            if ! kill -0 "$action_pid" 2>/dev/null; then stopped=true; break; fi
+            sleep 2
+          done
+          if [[ "$stopped" != "true" ]]; then
+            kill -KILL "$action_pid" 2>/dev/null || true
+            echo "Candidate did not complete best-effort SIGTERM finalization" >&2
+            exit 1
+          fi
+          set +e
+          wait "$action_pid"
+          action_status=$?
+          set -e
+          action_pid=""
+          [[ "$action_status" -ne 0 ]]
+          grep -q 'DSH_ABORTED' "$RUNNER_TEMP/dsh-e2e-cancel-output"
+
+          finalized=false
+          for _ in {1..60}; do
+            final_comment="$(gh api "repos/$REPOSITORY/issues/comments/$comment_id")"
+            if jq -e --arg run "$run_url" --argjson id "$comment_id" '
+              .id == $id and .user.id == 41898282 and
+              (.body | contains($run)) and
+              (.body | contains("DeepSeek Harness was cancelled")) and
+              ((.body | contains("In progress")) | not)
+            ' <<<"$final_comment" >/dev/null; then
+              finalized=true
+              break
+            fi
+            sleep 1
+          done
+          [[ "$finalized" == "true" ]]
+          mapfile -t final_ids < <(
+            gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100" --jq '.[].id'
+          )
+          [[ "${#final_ids[@]}" -eq 1 && "${final_ids[0]}" == "$comment_id" ]]
+
+          # This is the verifiable best-effort path. SIGKILL, runner loss, or host
+          # termination cannot execute JavaScript finalizers and cannot promise a
+          # final sticky-comment update.
+
+      - name: Delete only the isolated comment and close its issue
+        if: always()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          CANDIDATE_SHA: ${{ needs.gate.outputs.candidate_sha }}
+          ISSUE_NUMBER: ${{ steps.cancel_issue.outputs.number }}
+          ISSUE_ID: ${{ steps.cancel_issue.outputs.id }}
+          COMMENT_ID: ${{ steps.cancel_transition.outputs.comment_id }}
+        run: |
+          set -euo pipefail
+          [[ "$ISSUE_NUMBER" =~ ^[1-9][0-9]*$ ]]
+          [[ "$ISSUE_ID" =~ ^[1-9][0-9]*$ ]]
+          marker="<!-- dsh-e2e:cancellation:v1 run=$GITHUB_RUN_ID attempt=$GITHUB_RUN_ATTEMPT candidate=$CANDIDATE_SHA -->"
+          title="DSH E2E cancellation $GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT"
+          body="$(printf '%s\n\n%s' "$marker" "Temporary issue owned by the trusted Core E2E cancellation harness.")"
+          issue_json="$(gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER")"
+          jq -e --argjson number "$ISSUE_NUMBER" --argjson id "$ISSUE_ID" \
+            --arg title "$title" --arg body "$body" '
+            .number == $number and .id == $id and .state == "open" and
+            (has("pull_request") | not) and .user.id == 41898282 and
+            .title == $title and .body == $body
+          ' <<<"$issue_json" >/dev/null
+
+          mapfile -t comment_ids < <(
+            gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100" --jq '.[].id'
+          )
+          [[ "${#comment_ids[@]}" -le 1 ]]
+          comment_id="$COMMENT_ID"
+          if [[ "${#comment_ids[@]}" -eq 1 ]]; then
+            if [[ ! "$comment_id" =~ ^[1-9][0-9]*$ ]]; then comment_id="${comment_ids[0]}"; fi
+            [[ "$comment_id" == "${comment_ids[0]}" ]]
+            run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            comment_json="$(gh api "repos/$REPOSITORY/issues/comments/$comment_id")"
+            jq -e --argjson id "$comment_id" --arg run "$run_url" '
+              .id == $id and .user.id == 41898282 and (.body | contains($run))
+            ' <<<"$comment_json" >/dev/null
+            gh api --method DELETE "repos/$REPOSITORY/issues/comments/$comment_id"
+            if gh api "repos/$REPOSITORY/issues/comments/$comment_id" >/dev/null 2>&1; then
+              echo "The isolated cancellation comment still exists" >&2
+              exit 1
+            fi
+          else
+            [[ -z "$comment_id" ]]
+          fi
+
+          gh api --method PATCH "repos/$REPOSITORY/issues/$ISSUE_NUMBER" -f state=closed >/dev/null
+          closed_json="$(gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER")"
+          jq -e --argjson number "$ISSUE_NUMBER" --argjson id "$ISSUE_ID" \
+            --arg title "$title" --arg body "$body" '
+            .number == $number and .id == $id and .state == "closed" and
+            (has("pull_request") | not) and .user.id == 41898282 and
+            .title == $title and .body == $body
+          ' <<<"$closed_json" >/dev/null
+          [[ "$(gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100" --jq 'length')" -eq 0 ]]
+
+      - name: Assert cancellation made no candidate or task mutation
+        if: always()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          CANDIDATE_SHA: ${{ needs.gate.outputs.candidate_sha }}
+          CANDIDATE_PR: ${{ needs.gate.outputs.pull_request }}
+        run: |
+          set -euo pipefail
+          export LC_ALL=C
+          prefix="$RUNNER_TEMP/dsh-e2e-cancel-baseline"
+          current="$RUNNER_TEMP/dsh-e2e-cancel-current"
+
+          pr_json="$(gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR")"
+          jq -e --arg sha "$CANDIDATE_SHA" --arg repo "${REPOSITORY,,}" --arg base "$DEFAULT_BRANCH" '
+            .state == "open" and .draft == false and .head.sha == $sha and
+            (.head.repo.full_name | ascii_downcase) == $repo and
+            (.base.repo.full_name | ascii_downcase) == $repo and .base.ref == $base
+          ' <<<"$pr_json" >/dev/null
+          gh api "repos/$REPOSITORY/git/ref/heads/$DEFAULT_BRANCH" --jq .object.sha > "$current.main"
+          jq -cS '{
+            number,state,draft,
+            head:{repo:.head.repo.full_name,ref:.head.ref,sha:.head.sha},
+            base:{repo:.base.repo.full_name,ref:.base.ref,sha:.base.sha},
+            body:(.body // "")
+          }' <<<"$pr_json" > "$current.candidate"
+          gh api --paginate "repos/$REPOSITORY/issues/$CANDIDATE_PR/comments?per_page=100" \
+            --jq '.[] | {id,userId:.user.id,updatedAt:.updated_at,body}' \
+            | jq -cS . | sort > "$current.comments"
+          gh api --paginate "repos/$REPOSITORY/git/matching-refs/heads/dsh/task-?per_page=100" \
+            --jq '.[] | [.ref,.object.type,.object.sha] | @tsv' | sort > "$current.task-refs"
+          gh api --paginate "repos/$REPOSITORY/pulls?state=all&per_page=100" --jq '
+            .[] |
+            select(
+              ((.head.ref // "") | startswith("dsh/task-")) or
+              ((.body // "") | contains("<!-- dsh-action:task:v1 "))
+            ) |
+            {
+              number,state,draft,
+              head:{repo:.head.repo.full_name,ref:.head.ref,sha:.head.sha},
+              base:{repo:.base.repo.full_name,ref:.base.ref,sha:.base.sha},
+              bodyMarker:((.body // "") | contains("<!-- dsh-action:task:v1 ")),
+              body:(.body // "")
+            }
+          ' | jq -cS . | sort > "$current.task-prs"
+          for component in main candidate comments task-refs task-prs; do
+            cmp "$prefix.$component" "$current.$component"
+          done
+          ! git -C . config --local --get-regexp '^(http\..*\.extraheader|credential\.)' >/dev/null 2>&1
+          ! git -C candidate-action config --local --get-regexp '^(http\..*\.extraheader|credential\.)' >/dev/null 2>&1
+
+  revalidate_candidate:
+    name: Final candidate binding
+    needs: [gate, read_only, write, cancellation]
+    if: always() && needs.gate.result == 'success' && needs.gate.outputs.run_e2e == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Revalidate open same-repository candidate PR
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          CANDIDATE_SHA: ${{ needs.gate.outputs.candidate_sha }}
+          CANDIDATE_PR: ${{ needs.gate.outputs.pull_request }}
+        run: |
+          set -euo pipefail
+          pr_json="$(gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR")"
+          jq -e --arg sha "$CANDIDATE_SHA" --arg repo "${REPOSITORY,,}" --arg base "$DEFAULT_BRANCH" '
+            .state == "open" and .draft == false and .head.sha == $sha and
+            (.head.repo.full_name | ascii_downcase) == $repo and
+            (.base.repo.full_name | ascii_downcase) == $repo and .base.ref == $base
+          ' <<<"$pr_json" >/dev/null

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,7 +22,7 @@ export default tseslint.config(
     },
   },
   {
-    files: ["assets/**/*.mjs", "test/fixtures/**/*.mjs"],
+    files: [".github/e2e/**/*.mjs", "assets/**/*.mjs", "test/fixtures/**/*.mjs"],
     languageOptions: {
       parserOptions: { projectService: false },
       globals: {


### PR DESCRIPTION
## Purpose

Bootstrap the permanent trusted Core E2E harness on the default branch before any candidate product code is allowed to receive live-test credentials.

## Security model

- workflow_dispatch only; the secretless gate binds the live default-branch workflow SHA, explicit candidate SHA, repository variable, same-repository open PR, and a write-capable actor
- secret-bearing jobs use the core-e2e environment, which will be restricted to main before candidate qualification
- harness and fixtures come from the immutable trusted main SHA; candidate code is checked out separately at the bound SHA
- all checkouts use persist-credentials: false
- cancellation uses a dedicated temporary Issue and exact comment identity, with strict cleanup
- read-only paths snapshot candidate/task refs and PR state to detect mutation

## Scope

This PR contains only the E2E workflow, its two local fixtures, and the ESLint inclusion needed to validate those fixtures. The v0.5.1 product changes are intentionally excluded and will be reviewed in a separate PR.

## Verification

- workflow YAML parsed
- every fixture passed node --check and ESLint
- Prettier and git diff --check passed
- action metadata contract tests: 12/12