### PR TITLE
ci: exercise ordinary validation failure

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -468,7 +468,7 @@ jobs:
           progress-comment: "false"
           validation-integrity: strict
           run-tests: "true"
-          test-commands: '[["node","-e","process.exit(23)"]]'
+          test-commands: '[["false"]]'
           max-turns: "2"
           timeout-minutes: "15"
 
@@ -488,6 +488,9 @@ jobs:
             .conclusion == "failure" and .status == "validation_failed" and
             .error.code == "VALIDATION_FAILED" and .error.phase == "validation" and
             .validation.status == "failed" and
+            .validation.integrity.mode == "strict" and
+            .validation.integrity.status == "clean" and
+            .validation.integrity.dangerousChangeCount == 0 and
             (.loop.toolReceipts | any(.id == "command.prepare-validation" and .ok == true)) and
             (.loop.dshToolReceipts // [] | all(.id != "native.bash"))
           ' <<<"$RESULT_JSON" >/dev/null


### PR DESCRIPTION
Summary: replace the strict-integrity-incompatible inline Node eval with the statically classified passive false command, and assert Validation Integrity stays clean before the expected ordinary validation failure. Core E2E correctly fail-closed the previous command as an unresolved validation entrypoint; this trusted-harness-only change exercises VALIDATION_FAILED without weakening candidate code. Verified with git diff --check and the Prettier workflow check.