### PR TITLE
test: make trusted-write validation auditable

### DIFF
--- a/.github/e2e/assert-trusted-write.mjs
+++ b/.github/e2e/assert-trusted-write.mjs
@@ -1,0 +1,15 @@
+import { readFile } from "node:fs/promises";
+
+const [path, ...extra] = process.argv.slice(2);
+if (
+  path === undefined ||
+  extra.length !== 0 ||
+  !/^dsh-e2e-write-[1-9][0-9]*-[1-9][0-9]*\.txt$/u.test(path)
+) {
+  throw new Error("Expected one run-scoped trusted-write marker path");
+}
+
+const content = await readFile(path, "utf8");
+if (content !== "trusted-write\n") {
+  throw new Error("Trusted-write marker content did not match the golden value");
+}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -561,7 +561,7 @@ jobs:
           progress-comment: "false"
           validation-integrity: strict
           run-tests: "true"
-          test-commands: '[["node","-e","const fs=require(\"node:fs\");if(fs.readFileSync(process.argv[1],\"utf8\")!==\"trusted-write\\n\")process.exit(1)","dsh-e2e-write-${{ github.run_id }}-${{ github.run_attempt }}.txt"]]'
+          test-commands: '[["node",".github/e2e/assert-trusted-write.mjs","dsh-e2e-write-${{ github.run_id }}-${{ github.run_attempt }}.txt"]]'
           max-turns: "2"
           timeout-minutes: "18"
 


### PR DESCRIPTION
## Why

Core E2E run 32554624319 reached the trusted-write golden path and correctly failed closed because the harness still used inline `node -e` as its validator. Strict Validation Integrity cannot conservatively bind inline validation code.

## Change

- add a checked-in, run-scoped validator for the trusted-write marker
- call that immutable script by fixed argv from the E2E workflow
- keep the marker path and exact `trusted-write\n` content checks bounded

## Local validation

- `node --check .github/e2e/assert-trusted-write.mjs`
- Prettier check for the script and workflow
- ESLint via the existing local dependency runtime (no dependency reinstall)