### PR TITLE
docs: reorganize documentation for users and maintainers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing
+
+Thank you for improving DeepSeek Harness for GitHub.
+
+## Local development
+
+Use Node.js 24, then install from the committed lockfile and run the complete check:
+
+```bash
+npm ci
+npm run check
+```
+
+Add regression coverage for behavior changes. Keep changes focused and preserve the Controller/worker security boundary described in [SECURITY.md](SECURITY.md).
+
+## Pull requests
+
+1. Create a branch from the latest `main`.
+2. Make the smallest coherent change and update tests or documentation as needed.
+3. Run `npm run check` and review the full diff.
+4. Commit and push the branch, then open a PR to `main` with the change, risk, and verification clearly described.
+5. Fix failures and revalidate the latest PR head; results from an older SHA do not qualify a newer commit.
+
+Do not edit `dist/` by hand. Runtime changes must regenerate the committed bundle through the normal build and include the reviewed generated diff.
+
+Any DSH version bump requires a fresh compatibility and security audit of the exact package family, lockfile, Profile/Bundle/Plugin and MCP paths, native tools, ToolRuntime, receipts, Docker/network/path/timeout behavior, and `dist` packaging. Do not use version ranges, mixed DSH versions, floating refs, or dependency-resolution bypass flags.
+
+For release-specific steps, see [docs/maintainer-release.md](docs/maintainer-release.md). Report security vulnerabilities through GitHub private vulnerability reporting as described in [SECURITY.md](SECURITY.md#reporting-a-vulnerability).

--- a/README.md
+++ b/README.md
@@ -6,23 +6,30 @@
 
 [中文](README.zh-CN.md)
 
-Run DeepSeek Harness directly from GitHub pull requests, issues, and failed CI jobs.
+Run DeepSeek Harness directly from GitHub pull requests, issues, failed CI jobs, and maintainer-authored automations.
 
 ```text
 GitHub PR / Issue / CI  →  DeepSeek Harness  →  Review / Diagnose / Fix / Issue → PR
 ```
 
-It belongs to the same category of GitHub integration as [Claude Code Action](https://github.com/anthropics/claude-code-action): GitHub events start a coding agent, and the action writes reviews, diagnoses, or code changes back to the repository. This project uses DeepSeek Harness.
+The Action starts a credential-isolated DSH worker, validates its structured result, and lets a trusted Controller publish comments or validated changes. This is a community project, not an official DeepSeek or GitHub product. It is maintained by [@Lixiaoyiao](https://github.com/Lixiaoyiao).
 
-Pull requests can receive automatic inline reviews. Failed CI runs can receive a diagnosis. Once you explicitly enable write access, `@dsh` can also fix code or turn an issue into a pull request.
+## Core capabilities
 
-This is a community project. It is not an official DeepSeek or GitHub product.
+| Capability              | What it does                                                                                                                           |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Pull request review     | Reviews new commits, publishes one summary, and adds high-confidence inline findings                                                   |
+| General tasks           | Answers repository questions or performs an explicitly authorized coding task                                                          |
+| CI diagnosis and repair | Reads failed checks and logs; trusted workflows may validate and publish a fix                                                         |
+| Issue implementation    | Turns an authorized Issue request into a validated branch and pull request                                                             |
+| Controlled tools        | Offers `strict`, `standard`, and exact `custom` profiles for Bash, Web Search, Subagent, fixed commands, MCP, Bundle, and Plugin tools |
+| Structured results      | Reports stable scalar outputs plus a schema-v1 `result-json` envelope on success and failure                                           |
 
-Maintained by [@Lixiaoyiao](https://github.com/Lixiaoyiao).
+v0.5.1 uses exact, audited DeepSeek Harness `0.1.1-rc.2` package pins. Action inputs, outputs, GitHub permissions, and all write decisions remain Controller-owned.
 
 ## Live runs
 
-These are public runs from this repository. You can inspect the comments and Actions logs directly.
+These public runs show the comments and Actions logs produced by this repository.
 
 | Scenario                                                | Run                                                                                                                                                                   |
 | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -31,11 +38,9 @@ These are public runs from this repository. You can inspect the comments and Act
 | Fix and validation in trusted write mode                | [Actions run](https://github.com/Lixiaoyiao/deepseek-harness-action/actions/runs/31761793492)                                                                         |
 | Issue implementation followed by a pull request         | [Issue #4](https://github.com/Lixiaoyiao/deepseek-harness-action/issues/4) → [PR #5](https://github.com/Lixiaoyiao/deepseek-harness-action/pull/5)                    |
 
-## Quick start
+## Quick Start
 
-Add `DEEPSEEK_API_KEY` under **Settings → Secrets and variables → Actions** in your repository.
-
-Then create `.github/workflows/dsh-review.yml`:
+Add `DEEPSEEK_API_KEY` under **Settings → Secrets and variables → Actions**, then create `.github/workflows/dsh-review.yml`:
 
 ```yaml
 name: DSH review
@@ -65,336 +70,47 @@ jobs:
           dsh-version: 0.1.1-rc.2
 ```
 
-Open a non-draft pull request. The action reads the diff and repository context, then posts a review summary. When it finds a concrete problem, it also comments on the relevant line.
+Open a non-draft pull request. The Action checks out only the trusted base SHA, reads the pull request through GitHub APIs, and never executes fork code.
 
-See [`examples/fork-review.yml`](examples/fork-review.yml) for the complete template. This workflow uses `pull_request_target`, checks out only the trusted base SHA, and never runs code from the fork.
+For production, replace `v0.5.1` with the full immutable release commit SHA. See [Setup](docs/setup.md) for permissions, pinning, checkout rules, and complete templates.
 
-> This Quick start tracks the v0.5.1 release tag so new users start on the current version. For production, replace the tag with the full immutable commit SHA published for v0.5.1. Historical v0.3/v0.4/v0.5.0 behavior remains documented in [`CHANGELOG.md`](CHANGELOG.md).
+## Common `@dsh` commands
 
-## What it does
+Put the command on the first line of an Issue or pull request comment.
 
-| Entry point                                                | Result                                                               |
-| ---------------------------------------------------------- | -------------------------------------------------------------------- |
-| PR `opened` / `synchronize` / `ready_for_review`           | Automatic review with a summary and inline comments                  |
-| `@dsh task --read <question or task>`                      | General Q&A, code reading, and repository analysis                   |
-| `@dsh task --write <coding task>`                          | Change, validate, and deliver code after every write gate passes     |
-| An explicit non-empty `prompt` in a dispatch/schedule flow | Run a general automation task                                        |
-| `@dsh review`                                              | Review the current pull request again                                |
-| `@dsh diagnose`                                            | Read failed checks and logs, then identify the cause                 |
-| `@dsh fix`                                                 | Change code and run validation in trusted write mode                 |
-| `@dsh implement` on an issue                               | Understand the issue, change code, validate, and open a pull request |
+| Command                       | Purpose                                                            |
+| ----------------------------- | ------------------------------------------------------------------ |
+| `@dsh task --read <question>` | Explain code, inspect the repository, or answer a general question |
+| `@dsh task --write <task>`    | Request a coding task; every write gate must still pass            |
+| `@dsh review`                 | Review the current pull request again                              |
+| `@dsh diagnose`               | Diagnose failed checks and logs                                    |
+| `@dsh fix`                    | Repair a same-repository pull request in trusted write mode        |
+| `@dsh implement`              | Implement an Issue and open a pull request                         |
 
-The command must be on the first line of the comment. Ready-to-copy workflows are included:
-
-- [`examples/commands.yml`](examples/commands.yml) for `@dsh` commands, fixes, and Issue → PR
-- [`examples/ci-diagnose.yml`](examples/ci-diagnose.yml) for failed CI diagnosis
-- [`examples/ci-auto-fix.yml`](examples/ci-auto-fix.yml) for trusted CI auto-fix
-- [`examples/task-automation.yml`](examples/task-automation.yml) for v0.5.1 profile-based explicit-prompt automation
-- [`examples/controlled-extensions.yml`](examples/controlled-extensions.yml) for v0.5.1 custom MCP and DSH Bundle/Profile configuration
-
-Writing `@dsh fix` or `@dsh implement` does not grant write access by itself. The workflow must also set `allow-write: "true"`, keep `run-tests: "true"`, and provide at least one `test-commands` argv array. See [`action.yml`](action.yml) for all inputs.
-
-## General tasks and explicit automation
-
-`task` is not limited to the review, diagnose, fix, or implement templates. It can answer natural-language questions, inspect a repository, or carry out a coding task:
-
-```text
-@dsh task --read Explain why this pull request needs a two-phase commit
-@dsh task --write Add empty-input coverage to the parser and run validation
-```
-
-The command must start on the first line of the comment; later lines may continue the instructions. `--read` is the default for `task`. `--write` requests a capability but does not authorize it. The workflow still needs `allow-write: "true"`, `run-tests: "true"`, a non-empty validation command list, a same-repository context that is not `pull_request_target`, write/maintain/admin permission for every originating actor, and `workspace.edit` in the effective tool allowlist. A fork pull request can never be upgraded to write mode this way.
-
-On `workflow_dispatch`, `repository_dispatch`, or `schedule` automation events, `command: auto` plus a non-empty `prompt` routes to a general `task`. You may instead set `command: task`, in which case `prompt` is required. `task-access` defaults to `read`:
-
-```yaml
-with:
-  command: auto
-  prompt: "Check the dependency boundary, add tests if needed, and explain the result"
-  task-access: read
-```
-
-`prompt` is trusted control-plane configuration. Populate it only from a maintainer-authored workflow or a trusted dispatch input; do not silently promote issue bodies, pull-request content, logs, or other untrusted data into `prompt`. The same provenance rule applies to capability inputs, especially `permission-profile`, `allowed-tools`, `disallowed-tools`, `container-image`, `base-url`, `web-search-base-url`, `isolation`, and `dsh-executable`: they select authority, worker code, credential routing, or the process boundary. See [`examples/task-automation.yml`](examples/task-automation.yml) for the current profile-based read/write dispatch template.
-
-A read-only automation task without an issue or pull-request entity returns its answer through the step summary and outputs. A write task with no entity, or one targeting an issue, creates a dedicated `dsh/task-*` branch and pull request; the controller never pushes general automation changes directly to the default branch. An authorized task on a same-repository pull request can affect only the target branch that the controller bound and revalidated.
-
-## Multi-turn edit, validation, and repair loop
-
-The controller loop introduced in v0.3 remains the execution model in v0.5.1. It belongs to the Action controller, not to a shell inside DSH. Every iteration is a fresh DSH turn constrained by the same task anchor and capability policy:
-
-```text
-DSH turn
-  ├─ needs_tool → controller runs one allowed tool → bounded/redacted untrusted result → next turn
-  ├─ final → controller validation fails → stdout/stderr as untrusted feedback → next edit turn
-  ├─ final → validation passes → controller publishes, commits, or opens a pull request
-  └─ blocked → neutral only when no unresolved Controller validation failure is pending
-```
-
-The default `strict` Agent toolset has no shell. A trusted maintainer may select `standard` or an exact `custom` policy that exposes DSH's audited native Bash tool inside the credential-free Docker worker. No profile gives DSH GitHub credentials, the real DeepSeek key, permission to approve or expand its own tools, or commit/push/PR/release authority. An explicitly allowed third-party extension is trusted worker code and can have the process-level side effects described below. The controller owns validation, actual-change inspection, and every final GitHub mutation. `max-turns` (default 3) bounds all DSH turns consumed by tool requests and validation repairs; `timeout-minutes` is the deadline for the complete controller loop. If the same workspace revision produces the same validation failure twice, no-progress detection stops the loop. A repair turn cannot erase the pending validation failure by reporting `blocked`, exhausting its turns, or emitting malformed structured output: the original failure and any Validation Integrity audit remain authoritative until a later finalization passes. Independent cancellation, credential-leak, isolation, and runtime failures keep their own classifications. Turn/tool/validation-retry counts and bounded tool receipts are recorded under `result-json.loop`.
-
-## Permission profiles
-
-Most workflows need only one preset. Permission profiles control the Agent inside its sandbox; they do not grant GitHub authority.
-
-| Profile    | Intended use                              | Preset tools                                                                                         |
-| ---------- | ----------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `strict`   | Reviews and the v0.4-compatible default   | `workspace.read`, `workspace.search`, and policy-eligible `workspace.edit`                           |
-| `standard` | Trusted maintainer coding tasks           | The strict preset plus `native.bash`, Controller-mediated `native.web-search`, and `native.subagent` |
-| `custom`   | Exact tools, MCP, Bundle, or Plugin setup | No preset tools; list every required canonical ID explicitly                                         |
-
-`allowed-tools` adds exact IDs after preset expansion. `disallowed-tools` uses the same exact ID syntax and always wins. Valid families are `workspace.*`, `native.*`, `command.<name>`, `mcp.<server>.<tool>`, and `plugin.<extension>.<tool>`. A v0.4 workflow that used a smaller exact allowlist should select `custom`, or add matching deny entries, because an allowlist no longer replaces a `strict`/`standard` preset. The result is still intersected with actor, event, trust, workspace, network, extension, and Controller policy; a requested tool that crosses any boundary is denied fail-closed. `custom` is not a wildcard: it starts empty, and unknown, unavailable, omitted, or policy-ineligible IDs fail closed. The outputs and step summary report the resolved `permission-profile`, `effective-tools`, `network-access`, `workspace-write`, and `trusted-extensions`.
-
-`native.web-search` is mediated by the Controller through the configured DeepSeek web-search endpoint. It does not expose the real key to DSH or imply general bridge egress. `native.bash` requires trusted-write Docker and cannot share a worker with a bridge-networked extension. MCP, Bundle, and Plugin configuration is an advanced `custom` profile path because approved startup code is trusted worker code. The Agent cannot change its profile, allow/deny lists, extension configuration, or installation gate.
-
-## Maintainer-defined safe command tools
-
-`command.*` tools cannot accept or assemble model-provided argv. A maintainer defines the complete fixed argv for each command in a versioned `tool-config` manifest, then exposes its ID separately through `allowed-tools`:
-
-```yaml
-with:
-  permission-profile: custom
-  allowed-tools: '["workspace.read","workspace.search","workspace.edit","command.bundle-syntax"]'
-  tool-config: |
-    {
-      "schemaVersion": 1,
-      "commands": [{
-        "name": "bundle-syntax",
-        "description": "Check the bundled JavaScript syntax without installing dependencies",
-        "argv": ["node", "--check", "dist/index.js"],
-        "timeoutMinutes": 10,
-        "maxOutputBytes": 131072,
-        "maxCalls": 2,
-        "network": "none",
-        "workspaceAccess": "read"
-      }]
-    }
-```
-
-Replace the sample argv with a deterministic command for your repository. A command tool accepts no model arguments. Common direct shell executables are rejected as an additional guard; undefined tools, calls beyond `maxCalls`, and network/workspace access that exceeds the current policy also fail. The primary boundary is maintainer-fixed complete argv, no model-added arguments, and a credential-isolated container pinned by full digest. Controller credentials are rejected if a workflow interpolates them into command-tool or validation argv. stdout/stderr is bounded and redacted, then returned only as untrusted feedback. A manifest entry alone grants nothing: its ID must also appear in `allowed-tools`, and the current security policy must allow the required execute/write/network capability. The separate `native.bash` tool is available only through an explicit `standard`/`custom` profile after trusted-write Docker policy checks; it runs bounded foreground commands, inherits the sandbox and credential isolation, and never receives approval to escalate.
-
-## Official MCP, Bundle, and Profile integration
-
-v0.5.1 upgrades the complete audited DSH dependency set from `0.1.0-rc.8` to exact `0.1.1-rc.2` pins, including `@deepseek-ai/dsh`, app-boot, the official MCP client, Profile/Bundle support, native tools, and their directly used packages. The rc.2 review covered app-boot, Profile/Bundle/Plugin loading, MCP, ToolRuntime, Bash, Web Search, Subagent, receipts, and Docker/path/timeout behavior; it found no need to change existing Action inputs, outputs, or permission semantics. The controller still generates the controlled `github-action` Profile and Cordis patch and starts it through `@deepseek-ai/dsh-app-boot@0.1.1-rc.2`, without a parallel MCP client or plugin loader. This path skips workspace and `$DSH_HOME` `.env` discovery and the general CLI's dynamic user-patch watch/hot-reload path. All shipped DSH dependencies are exact lockfile pins; `latest`, semver ranges, floating Git refs, and legacy MCP SSE are rejected.
-
-The controlled root Profile places the Action's machine-output protocol after rc.2 tool-specific system guidance and binds the JSON `operation` field to the exact Controller-selected operation; the Agent cannot reinterpret a `task` as `implement` merely because it edits files. In particular, Web Search citations may use Markdown only inside JSON string fields; the root Agent must still return one complete schema-v1 JSON object, and operation changes, fences, prefaces, suffixes, or a separate citation list are rejected. This root-only section is empty for `native.subagent`, whose ordinary response is returned to the parent Agent instead of the Action output boundary.
-
-The official MCP client supports the transports exposed here:
-
-- `stdio`: the command must be a bare executable name or absolute container path outside `/workspace`. Shells, interpreters, downloaders, package managers, Git, and dynamic runners such as `npx` are rejected. `cwd` is repository-relative. Starting the approved executable grants full trusted worker-code execution inside the container; it is not merely a tool schema.
-- `streamable-http`: the URL must use HTTP(S), cannot contain embedded credentials or a fragment, and the server and each exposed tool must explicitly request `network`. Structured audit output and its public profile digest expose only the URL origin; pathname, query, and headers are withheld. A separate Controller-only digest binds the complete validated configuration for runtime reuse.
-
-`mcp-config` is a versioned, strict server-and-tool allowlist. Defining a server is not enough: every exposed tool must also appear in `allowed-tools` as `mcp.<server-id>.<tool-id>`. The controller derives the official DSH model-facing `mcp__...` name itself, so a prompt cannot add servers, rename tools, or expand their permissions. For example:
-
-```yaml
-with:
-  permission-profile: custom
-  allowed-tools: '["workspace.read","workspace.search","mcp.repo-index.lookup"]'
-  mcp-config: |
-    {
-      "schemaVersion": 1,
-      "servers": [{
-        "id": "repo-index",
-        "transport": "stdio",
-        "command": "/opt/dsh-extensions/bin/repository-index-mcp",
-        "args": ["--stdio"],
-        "cwd": ".",
-        "network": false,
-        "maxCalls": 8,
-        "tools": [{
-          "id": "lookup",
-          "name": "lookup",
-          "description": "Search the prebuilt repository index",
-          "permissions": ["read"],
-          "timeoutMs": 15000,
-          "maxOutputBytes": 65536,
-          "maxCalls": 4
-        }]
-      }]
-    }
-```
-
-The sample executable is intentionally image-provided: build and audit it into the digest-pinned `container-image`; do not download a server from the model turn. Any effective MCP, Bundle, or plugin tool requires `isolation: docker`; the local `dsh-executable` compatibility path cannot load extensions. [`examples/controlled-extensions.yml`](examples/controlled-extensions.yml) also shows the `streamable-http` shape and the controlled Profile/Bundle path.
-
-`plugin-config` uses the official Bundle/Profile mechanism. Each Bundle or plugin needs an explicit package name, an exact semver or `git+https://github.com/...git#<40-character-commit>` source, declared tools, and declared network behavior. Package tools use the action ID `plugin.<extension-id>.<tool-id>` and a namespaced DSH runtime name beginning with `plugin__<extension-id>__`. Third-party package installation is disabled until a trusted workflow sets `allow-plugin-install: "true"`.
-
-> A third-party Bundle or plugin executes full trusted worker code during DSH startup. NPM lifecycle scripts are disabled during acquisition, but tool-call allowlists do not sandbox package initialization, background work, or direct process I/O. Review the package and its transitive dependency graph, pin it immutably, use a dedicated runner or image when appropriate, and grant network/workspace access as if you were authorizing code execution on that worker. `allow-plugin-install` is never inferred from a prompt, PR, Issue, repository file, or model output.
-
-Before installing an effective third-party package, the Controller snapshots the complete top-level runtime package inventory. It verifies the inventory again after installation and aborts if any pre-existing package was removed or its version changed, then separately verifies the configured extension's package identity and exact version or commit.
-
-All tool families are compiled from the same controller policy and fail closed:
-
-| Limit             | Enforcement                                                                                                          |
-| ----------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `read`            | Requires repository-read capability; unavailable to the untrusted fork profile                                       |
-| `workspace-write` | Requires trusted-write, `allow-write: "true"`, same-repository origin, actor checks, and final controller validation |
-| `network`         | Must be declared by the owner and each tool and allowed by the effective controller policy                           |
-| `timeoutMs`       | Bounds one invocation; same-process plugin cancellation is cooperative, while the overall deadline hard-stops DSH    |
-| `maxOutputBytes`  | Bounds serialized tool output before it is returned as untrusted model feedback                                      |
-| `maxCalls`        | Bounds a tool and its owning server/package across the controller's multi-turn loop                                  |
-
-The Action-owned policy adapter applies this positive runtime allowlist to model-routed DSH native, official MCP, and plugin tool invocations. The existing controller `ToolRouter` continues to execute fixed-argv `command.*` tools. Both planes use the same controller-resolved capabilities, limits, audit identity, and bounded receipts. This controls what the model can route; it cannot contain an actively malicious already-approved stdio server, Bundle, or plugin that performs startup, background, or direct process I/O. The Agent itself gets no unrestricted shell, `GITHUB_TOKEN`, real DeepSeek key, or commit/push/PR authority.
-
-Before restriction, every visible runtime tool must belong to the Controller-audited inventory and every selected tool must be present; a configured but unselected tool is not required to register. After restriction, the model-visible inventory must equal the selected allowlist exactly. Unknown tools, missing selected tools, and agent-scoped tools that survive outside the allowlist all fail closed, while the monotonic ToolRuntime guard independently denies every call without an effective Controller rule.
-
-Network and workspace mounts apply to the whole DSH process, not one tool. Every extension tool must therefore declare `read`, because its process shares the Agent's repository view. All effective MCP servers/packages in a turn must declare the same network and workspace-write mode. A trusted-read worker accepts only read-only owners; every owner co-hosted in a trusted-write worker must explicitly declare `workspace-write`. Mixed modes are rejected instead of being presented as per-tool isolation. `network: false` means the internal Docker network blocks ordinary external egress, not that the worker has no network path: DSH still reaches the controller-side LLM proxy by mapping `host.docker.internal` to the network's inspected IPv4 gateway. That is why the effective permission output reports `host-gateway` instead of `none`. The host-gateway path is not a port allowlist, runner firewall policy governs access to other host services, and package acquisition separately uses bridge networking.
-
-See [`docs/extension-contracts.md`](docs/extension-contracts.md) for the exact Profile composition, identifier mapping, process-level compatibility rules, receipt shape, and deferred session boundary.
-
-### Compatibility
-
-The default `strict` profile preserves the v0.4/v0.5.0 review, diagnose, fix, implement, auto, task, multi-turn, sticky-comment, and Controller-owned GitHub-write paths. Existing input names, scalar outputs, and the schema-v1 `result-json` envelope remain compatible. v0.5.1 is a runtime-compatibility, architecture, and stability release; it does not add Session/Resume, Label/Assignee triggers, custom trigger phrases, branch templates, Agent Teams, a GitHub App/installer, or unrelated product expansion.
-
-## Progress and structured outputs
-
-When an authorized read-only operation resolves to a pull request or issue, the controller updates one sticky comment while it prepares bounded context, runs DSH, and publishes the result. A write request deliberately publishes no lifecycle or status comment before every final Controller validation command succeeds; after the validated mutation, its final result may reuse the same controller-owned v1 marker. Progress therefore does not create a second status comment:
-
-| Operation           | Reused sticky marker |
-| ------------------- | -------------------- |
-| `task`              | `task`               |
-| `review`            | `summary`            |
-| `diagnose`          | `diagnosis`          |
-| `fix` / `implement` | `write`              |
-
-On success, the detailed review, diagnosis, or validated write result replaces that same comment. A read-only failure can update it with a stable error code, phase, redacted bounded message, and next step. If an authorized `@dsh task --write` finishes with no repository changes, the Controller makes no commit, ref, pull-request, or release mutation but still publishes the final answer to the resolved Issue/PR and records the no-change result in outputs and the step summary. A blocked request or a write that fails before/during final validation still emits only outputs and a step summary. Only markers authored by the expected numeric bot ID are updated; user-forged markers are ignored. Eligible lifecycle comment updates are best effort, so a temporary GitHub comments API failure does not hide the real agent, validation, or write outcome.
-
-On `SIGTERM` or `SIGINT`, v0.5.1 aborts the active worker and immediately starts a bounded, best-effort terminal lifecycle update while run-scoped cleanup proceeds. A later authoritative non-cancellation failure can correct a provisional cancellation state, and terminal-state guards prevent queued “In progress” work from overwriting the result. A forced `SIGKILL`, runner/host loss, process crash, or a network/GitHub API outage can prevent all finalization code from running, so a sticky comment can still remain at “In progress.” Workflow concurrency remains important, and operators should diagnose the authoritative Actions conclusion rather than treating a stale comment as proof that work is still running.
-
-`progress-comment` defaults to `true`. Disable intermediate lifecycle updates with:
-
-```yaml
-with:
-  progress-comment: "false"
-```
-
-This disables lifecycle updates only. It does not disable normal inline review comments, review summaries, CI diagnoses, or final fix status publication.
-
-Keep the job-level `timeout-minutes` a few minutes above the action input of the same name. This gives the internal DSH watchdog time to stop the worker and finalize failure outputs, the step summary, and any eligible read-only sticky comment. Runtime creation and installation, extension installation, each Agent turn, and validation each receive the smaller of their own cap and the remaining overall execution deadline, so setup cannot silently consume the complete task budget. Cleanup and cancellation-comment finalization instead receive separate, fixed short best-effort grace periods after the outcome or deadline; they cannot hang indefinitely, but they can extend wall-clock time slightly beyond the configured execution deadline.
-
-The action sets `result-json` on success, neutral, and failure paths. This is a `schemaVersion: 1` JSON envelope containing the applicable `status`, operation, summary, timing, policy/capabilities, permission audit, effective extension audit, bounded tool receipts, actual isolation report, publication statistics, controller validation and validation-integrity audit, write result, sticky comment ID, and error. `status` is one of `success`, `neutral`, `failed`, `timed_out`, `validation_failed`, or `denied`. `validation_failed` covers both invalid DSH structured output and controller validation failure; `error.code` distinguishes them. A failure object carries stable `code`, `phase`, `title`, `message`, `guidance`, and `retryable` fields.
-
-All scalar outputs are:
-
-| Output                     | Meaning                                                                               |
-| -------------------------- | ------------------------------------------------------------------------------------- |
-| `conclusion`               | `success`, `neutral`, or `failure`                                                    |
-| `operation`                | `task`, `review`, `diagnose`, `fix`, `implement`, or `none`                           |
-| `summary`                  | Validated summary for any operation, or a safe failure summary                        |
-| `review-summary`           | Backward-compatible alias of `summary`                                                |
-| `findings-count`           | Selected review findings, or validated agent findings for other operations            |
-| `branch-name`              | Created DSH branch, empty when not applicable                                         |
-| `pull-request-url`         | Created pull request URL, empty when not applicable                                   |
-| `commit-sha`               | Commit created by a successful fix, empty when not applicable                         |
-| `trust`                    | `untrusted`, `trusted-read`, `trusted-write`, or `none` before policy resolution      |
-| `permission-profile`       | Resolved `strict`, `standard`, `custom`, or `none` Agent permission preset            |
-| `effective-tools`          | JSON array of exact tools left after preset, deny, trust, and policy checks           |
-| `network-access`           | Effective worker path: `host-gateway`, `mediated-web`, `bridge`, or unresolved `none` |
-| `workspace-write`          | Whether effective Agent tools can modify the disposable workspace                     |
-| `trusted-extensions`       | JSON array of Controller-approved MCP, Bundle, and Plugin owners                      |
-| `duration-ms`              | Total controller duration in milliseconds                                             |
-| `comment-id`               | Sticky progress/result comment ID when available                                      |
-| `error-code`               | Stable failure code; empty on success or neutral completion                           |
-| `error-message`            | Redacted and bounded failure message                                                  |
-| `extension-profile-digest` | SHA-256 digest of the redacted effective Profile audit; empty when unavailable        |
-| `tool-receipts`            | JSON object with bounded `controller`/`dsh` arrays plus truncation metadata           |
-| `result-json`              | The versioned JSON envelope described above                                           |
-
-The v0.1.0 outputs `conclusion`, `operation`, `review-summary`, `findings-count`, `branch-name`, and `pull-request-url` remain available, so existing workflows do not need to be rewritten. Model-reported `verification` and controller-executed validation are different data; `result-json` exposes the latter separately under `validation`.
-
-A failed action step still writes its outputs first. Use `always()` in a later step and pass the value through an environment variable instead of interpolating model-derived text into a script:
-
-```yaml
-# First give the DeepSeek Harness step id: dsh
-- name: Inspect DSH result
-  if: ${{ always() && steps.dsh.outputs['result-json'] != '' }}
-  env:
-    DSH_RESULT_JSON: ${{ steps.dsh.outputs['result-json'] }}
-  run: printf '%s\n' "$DSH_RESULT_JSON" | jq .
-```
-
-Summaries, paths, and other model-derived strings inside `result-json` remain untrusted data. The envelope, invocation-count state, and receipts are telemetry only, not authorization or tamper-proof security logs. Approved extension code shares the worker process/filesystem and can influence that telemetry, so do not splice output strings directly into shell commands or treat them as independent proof.
-
-## Write mode
-
-`allow-write` defaults to `false`. Every code, Git ref, pull-request, and write-task comment mutation requires `run-tests: "true"`, at least one `test-commands` argv array, and successful completion of every validation command. `run-tests: "false"` denies the mutation; it is not a waiver. This is an intentional v0.4 security hardening from earlier behavior. Until that gate succeeds—or actual-change inspection confirms a no-change task—there is no GitHub comment, commit, ref update, or pull request. A no-change task may publish only its final answer. Repository mutations remain limited to trusted actors working in the same repository, and fork pull requests are always review-only. Validation commands are argv arrays and are not expanded by a shell:
-
-```yaml
-with:
-  allow-write: "true"
-  permission-profile: standard
-  run-tests: "true"
-  validation-integrity: strict
-  test-commands: '[["npm","ci","--ignore-scripts"],["npm","test"],["npm","run","typecheck"]]'
-  container-image: docker.io/library/node:24.18.0-bookworm@sha256:5711a0d445a1af54af9589066c646df387d1831a608226f4cd694fc59e745059
-```
-
-Write mode and any effective extension require a complete Docker image digest. Every image value, including tag-compatible read-only paths, is validated as one Docker/OCI reference and cannot begin with an option or contain argument-breaking whitespace. The image itself is trusted worker code. Docker must be available on the runner.
-
-### Validation-definition integrity
-
-The Controller separately detects changes that can redefine what “validation passed” means: package scripts, test sources/configuration, lint, typecheck, build configuration, and other validation entrypoints. This does not prohibit changing tests alongside code.
-
-- `off` records and reports validation-definition changes without blocking them.
-- `warn` is the default; it reports the changed categories and suspicious weakening signals.
-- `strict` blocks high-confidence weakening (including truncated audits) and, when a control-plane definition changed without an obvious weakening signal, replays the configured validation against the candidate code while restoring the baseline validation definitions.
-
-The mode is trusted workflow configuration. Repository content and the model cannot lower it. The audit and disposition are written to `result-json` and the step summary before the Controller considers any GitHub mutation.
+`--write`, `fix`, and `implement` request capabilities; they do not grant them. The workflow must explicitly enable write mode and provide Controller-run validation. See [Usage](docs/usage.md) for commands and automation, and [Configuration](docs/configuration.md) for the gates.
 
 ## Security
 
-The security model has four separate layers so that a trusted actor is never confused with trusted repository content:
+- The Agent receives neither the real `GITHUB_TOKEN` nor the real DeepSeek key. Only the Controller can call GitHub mutation APIs.
+- Repository content, diffs, issues, pull requests, comments, logs, model output, and tool output remain untrusted data.
+- Fork review uses a `.git`-less, credential-free worker and must check out only the trusted base SHA with `persist-credentials: false`.
+- Writes require a trusted same-repository context, authorized actors, Docker, `allow-write: "true"`, non-empty fixed validation commands, and successful validation. Protected-path and Validation Integrity checks still apply.
+- An approved Bundle, Plugin, or stdio MCP server is trusted worker code. ToolRuntime limits model-routed calls; it does not sandbox extension startup, background work, or direct process I/O.
 
-1. **Actor / control plane:** interactive `@dsh` commands require every originating actor to pass the write/maintain/admin check. Writes additionally require explicit `allow-write: "true"` and mandatory successful validation. Capability-bearing inputs such as `permission-profile`, exact allow/deny lists, `validation-integrity`, `container-image`, credential-routing URLs, `isolation`, and `dsh-executable` must come only from trusted workflow configuration. Workflow token scopes only determine which GitHub APIs the controller may call; they cannot bypass actor or policy gates.
-2. **Input data:** repository files, diffs, CI logs, README/AGENTS/CLAUDE files, issues, pull requests, and comments always remain untrusted. Model output receives no authority directly and must pass strict schema, path, size, and marker validation.
-3. **Worker:** `untrusted`, `trusted-read`, and `trusted-write` are trust profiles; `strict`, `standard`, and `custom` are a separate Agent-permission dimension. Forks receive no repository tools. Trusted standard/custom workers may expose audited native tools inside the credential-free Docker boundary, but never direct GitHub access.
-4. **Controller / commit authority:** only the controller holds the GitHub client and real credentials. It rebinds SHA and issue/PR identity, runs credential-free validation, checks actual file changes, and finally comments, commits, pushes, or opens a pull request.
+Read the complete [Security policy](SECURITY.md) before enabling write mode, host execution, network access, or third-party extensions.
 
-Workflow permissions used by the supplied templates are:
+## Documentation
 
-| Scenario                                 | Workflow token permissions                                                                  |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------- |
-| Automatic or fork PR review              | `contents: read`, `pull-requests: write`                                                    |
-| Read-only general task                   | `contents: read`; add the matching write scope only when an Issue/PR sticky comment is used |
-| Automation task that creates a branch/PR | `contents: write`, `pull-requests: write`                                                   |
-| CI diagnosis                             | `actions: read`, `checks: read`, `contents: read`, `issues: write`, `pull-requests: write`  |
-| Commands that support fix / implement    | `contents: write`, `actions: read`, `checks: read`, `issues: write`, `pull-requests: write` |
-| CI auto-fix                              | Same as the preceding row                                                                   |
-
-Progress comments reuse the same permissions as final result comments and require no new scope. `GITHUB_TOKEN` remains in the controller, while the controller-side proxy injects the DeepSeek key; neither credential enters the DSH prompt, workspace, MCP/Plugin configuration, worker argv/environment, or validation commands. Input and pre-launch checks reject accidental interpolation without echoing the credential. See [`SECURITY.md`](SECURITY.md) for the full trust model, known limitations, and vulnerability reporting. v0.5.1 accepts only the audited `@deepseek-ai/dsh@0.1.1-rc.2` family and committed exact lock; another version requires a matching policy/profile review.
-
-## Architecture
-
-```text
-GitHub event
-    ↓
-Action controller: route → authorize → compile permission profile + exact allow/deny
-    ↓
-Controller-owned sticky progress for read-only operations → bounded workspace / context
-    ↓
-Fresh DSH turn in Docker
-    ├─ DSH native / official MCP / Plugin tool → positive Action policy → receipt
-    ├─ needs_tool → controller fixed-argv tool ──────────────────────────┐
-    └─ final → validation + validation-integrity failure ────────────────┤ bounded untrusted feedback
-                                                                         └→ next DSH turn (max-turns/deadline)
-    ↓
-Action controller: final schema + gates → answer / commit / branch + PR
-                                      (write-task comments begin only here)
-    ↓
-Action outputs: legacy scalars + versioned result-json
-```
-
-The DSH worker does not hold a GitHub client. Model output must pass schema validation before the controller maps it to diff lines or invokes an authorized tool. Read-only tracking comments remain Controller-owned; write-task comments and every trusted write additionally wait for successful final repository validation. The controlled Profile is generated only from trusted workflow inputs after Controller validation; repository content and model output cannot modify the MCP/Bundle/Plugin set.
-
-v0.5.1 keeps that external flow while separating runtime installation and inventory audit, process launch, Docker/network policy, Profile setup, receipt reconciliation, timeout, and cleanup into run-scoped responsibilities. Validation integrity likewise builds a normalized command graph before planning any baseline replay. Receipt collection advances from the prior byte offset and uses set-based reconciliation, avoiding repeated whole-file scans without changing the public output format.
-
-## Core release E2E
-
-The permanent [Core E2E workflow](.github/workflows/e2e.yml) must first be reviewed and merged to the default branch as trusted harness code. A maintainer then dispatches that default-branch workflow with the full candidate SHA and its open, non-draft, same-repository PR number after setting `DSH_E2E_CANDIDATE_SHA` to the same SHA. The gate has no secret access: it requires a write-capable actor, binds the PR head and default base, and verifies that the dispatch/workflow SHA equals the live default-branch SHA. The read-only, write, and cancellation jobs all use the protected `core-e2e` environment; configure that environment to allow only the default branch before adding `DEEPSEEK_API_KEY`.
-
-Harness files and fixtures are checked out at the immutable default-branch SHA emitted by the gate, while candidate Action code is checked out only at the separately bound candidate SHA and every checkout uses `persist-credentials: false`. No-mutation paths compare default-branch state, the complete candidate identity/comments, every `dsh/task-*` ref with its object type/SHA, and Controller task-PR state/draft/head/base/body data. The cancellation path creates a run/attempt/candidate-marked temporary Issue, locks the single bot comment ID through its in-progress-to-cancelled transition, then strictly deletes that comment and closes the Issue; it never reuses or overwrites the candidate PR sticky comment.
-
-## Release canary
-
-The lightweight [release canary](.github/workflows/release-canary.yml) runs weekly or manually with `contents: read`, one `strict` read-only task, and no matrix or mutation scope. Its secretless gate requires the workflow ref to be `refs/heads/main` and the run/workflow SHA to equal the live default-branch SHA; the secret-bearing smoke job uses the same protected, main-only `core-e2e` environment as Core E2E. Release maintainers set repository variable `DSH_RELEASE_CANARY_SHA` to the lowercase, full 40-character commit SHA referenced by the formal v0.5.1 tag and GitHub Release, and provide `DEEPSEEK_API_KEY`. The workflow verifies that the tag, non-draft/non-prerelease Release, and variable resolve to the same immutable commit before checkout and local Action execution.
+| Guide                                                       | Contents                                                                             |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| [Setup](docs/setup.md) · [中文](docs/setup.zh-CN.md)        | Secret, first workflow, permissions, safe checkout, and templates                    |
+| [Usage](docs/usage.md) · [中文](docs/usage.zh-CN.md)        | `@dsh` commands, tasks, review, diagnose, fix, implement, and automation             |
+| [Configuration](docs/configuration.md)                      | Inputs, permission profiles, tools, validation, extensions, and outputs              |
+| [Troubleshooting](docs/troubleshooting.md)                  | Denials, Docker, timeouts, cancellation, validation, and extension failures          |
+| [Security policy](SECURITY.md)                              | Trust model, credential boundaries, network behavior, and known limitations          |
+| [Extension contracts](docs/extension-contracts.md)          | Deep technical contracts for MCP, Profile, Bundle, Plugin, ToolRuntime, and receipts |
+| [Maintainer release guide](docs/maintainer-release.md)      | Local checks, Core E2E, release canary, version updates, and publishing              |
+| [Contributing](CONTRIBUTING.md) · [Changelog](CHANGELOG.md) | Development workflow and release history                                             |
 
 ## Development
 
@@ -405,14 +121,10 @@ npm ci
 npm run check
 ```
 
-The `dist/` bundle used by GitHub Marketplace is committed with each release. See [`BUNDLED_DEPENDENCIES.md`](BUNDLED_DEPENDENCIES.md) for dependency and bundling details.
+See [CONTRIBUTING.md](CONTRIBUTING.md). The Marketplace `dist/` bundle is committed for releases and must not be edited by hand.
 
 ## License
 
-[MIT](LICENSE). Third-party licenses are listed in [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md).
+[MIT](LICENSE). Third-party licenses are listed in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) and [BUNDLED_DEPENDENCIES.md](BUNDLED_DEPENDENCIES.md).
 
-## Acknowledgements
-
-- [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) provides the headless runtime, MCP client, Bundle/Profile loading, and Cordis configuration used by this project.
-- The GitHub event routing, permission checks, and tracking model are adapted from the MIT-licensed [Claude Code Action](https://github.com/anthropics/claude-code-action). The exact upstream commit and license text are recorded in [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md).
-- The structured-output and execution/publication permission separation also draw on the design of [Codex GitHub Action](https://learn.chatgpt.com/docs/github-action); this project retains its own controller/worker trust boundary and result protocol.
+DeepSeek Harness supplies the headless runtime and official extension mechanisms. The GitHub integration also draws on the MIT-licensed [Claude Code Action](https://github.com/anthropics/claude-code-action) patterns and the execution/publication separation described by [Codex GitHub Action](https://learn.chatgpt.com/docs/github-action); exact attributions are recorded in the third-party notices.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,36 +6,41 @@
 
 [English](README.md)
 
-让 GitHub 里的 PR、Issue 和失败 CI 直接调用 DeepSeek Harness。
+让 GitHub 里的 PR、Issue、失败 CI 和维护者编写的自动化流程直接调用 DeepSeek Harness。
 
 ```text
 GitHub PR / Issue / CI  →  DeepSeek Harness  →  Review / Diagnose / Fix / Issue → PR
 ```
 
-它和 [Claude Code Action](https://github.com/anthropics/claude-code-action) 属于同一类 GitHub 集成：由 GitHub 事件启动 coding agent，再把 review、诊断或代码改动写回仓库。这个项目使用的是 DeepSeek Harness。
+Action 会启动与凭据隔离的 DSH worker，校验结构化结果，再由受信任的 Controller 发布评论或经过验证的改动。这是社区项目，并非 DeepSeek 或 GitHub 官方产品，由 [@Lixiaoyiao](https://github.com/Lixiaoyiao) 维护。
 
-PR 可以自动收到行内 review；失败的 CI 可以得到诊断；在你明确开放写权限后，`@dsh` 也可以修代码或把 Issue 做成 PR。
+## 核心能力
 
-这是由社区维护的项目，不是 DeepSeek 或 GitHub 官方产品。
+| 能力          | 作用                                                                                                             |
+| ------------- | ---------------------------------------------------------------------------------------------------------------- |
+| PR 审查       | 审查新提交，发布一条汇总，并为高置信度问题添加行内评论                                                           |
+| 通用任务      | 回答仓库问题，或执行经过明确授权的编码任务                                                                       |
+| CI 诊断与修复 | 读取失败的检查和日志；受信任 workflow 可以验证并发布修复                                                         |
+| Issue 实现    | 把经过授权的 Issue 请求实现为已验证的分支和 PR                                                                   |
+| 受控工具      | 通过 `strict`、`standard` 和精确的 `custom` 档位使用 Bash、Web Search、Subagent、固定命令、MCP、Bundle 与 Plugin |
+| 结构化结果    | 无论成功或失败，都提供稳定的标量 outputs 和 schema-v1 `result-json`                                              |
 
-Maintained by [@Lixiaoyiao](https://github.com/Lixiaoyiao).
+v0.5.1 对 DeepSeek Harness `0.1.1-rc.2` 使用经过审计的精确版本固定。Action 的输入、输出、GitHub 权限和所有写入决定仍由 Controller 掌握。
 
 ## 真实运行
 
-下面都是这个仓库自己的公开运行记录，可以直接查看评论和 Actions 日志。
+以下是本仓库的公开运行记录，可以直接查看评论和 Actions 日志。
 
 | 场景                            | 运行记录                                                                                                                                                              |
 | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| PR Review，以及复跑不重复发评论 | [PR #3](https://github.com/Lixiaoyiao/deepseek-harness-action/pull/3) · [Actions run](https://github.com/Lixiaoyiao/deepseek-harness-action/actions/runs/31760570162) |
-| 读取失败 check 和日志后给出诊断 | [Actions run](https://github.com/Lixiaoyiao/deepseek-harness-action/actions/runs/31760603284)                                                                         |
-| 受信任写模式下修复并验证        | [Actions run](https://github.com/Lixiaoyiao/deepseek-harness-action/actions/runs/31761793492)                                                                         |
-| 从 Issue 实现代码并创建 PR      | [Issue #4](https://github.com/Lixiaoyiao/deepseek-harness-action/issues/4) → [PR #5](https://github.com/Lixiaoyiao/deepseek-harness-action/pull/5)                    |
+| PR 审查，以及复跑时不重复发评论 | [PR #3](https://github.com/Lixiaoyiao/deepseek-harness-action/pull/3) · [Actions run](https://github.com/Lixiaoyiao/deepseek-harness-action/actions/runs/31760570162) |
+| 根据失败的检查和日志进行诊断    | [Actions run](https://github.com/Lixiaoyiao/deepseek-harness-action/actions/runs/31760603284)                                                                         |
+| 在受信任写模式下修复并验证      | [Actions run](https://github.com/Lixiaoyiao/deepseek-harness-action/actions/runs/31761793492)                                                                         |
+| 实现 Issue 后创建 PR            | [Issue #4](https://github.com/Lixiaoyiao/deepseek-harness-action/issues/4) → [PR #5](https://github.com/Lixiaoyiao/deepseek-harness-action/pull/5)                    |
 
 ## 快速开始
 
-先在仓库的 **Settings → Secrets and variables → Actions** 中添加 `DEEPSEEK_API_KEY`。
-
-然后创建 `.github/workflows/dsh-review.yml`：
+先在仓库的 **Settings → Secrets and variables → Actions** 中添加 `DEEPSEEK_API_KEY`，再创建 `.github/workflows/dsh-review.yml`：
 
 ```yaml
 name: DSH review
@@ -65,336 +70,47 @@ jobs:
           dsh-version: 0.1.1-rc.2
 ```
 
-现在打开一个非 draft PR。Action 会读取 diff 和仓库上下文，并发布 review summary；有确定问题时，也会在对应代码行留下评论。
-
-完整模板见 [`examples/fork-review.yml`](examples/fork-review.yml)。这个 workflow 使用 `pull_request_target`，只 checkout 受信任的 base SHA，不会运行 fork 里的代码。
-
-> 此 Quick start 跟随 v0.5.1 release Tag，让新用户默认使用当前版本。生产环境请把 Tag 替换为 v0.5.1 发布时给出的完整不可变 commit SHA。v0.3/v0.4/v0.5.0 的历史行为仍保留在 [`CHANGELOG.md`](CHANGELOG.md) 中。
-
-## 能做什么
-
-| 入口                                                 | 结果                                       |
-| ---------------------------------------------------- | ------------------------------------------ |
-| PR `opened` / `synchronize` / `ready_for_review`     | 自动 review，发布 summary 和行内评论       |
-| `@dsh task --read <问题或任务>`                      | 通用问答、代码阅读和仓库分析               |
-| `@dsh task --write <编码任务>`                       | 在全部写入 gate 通过后修改、验证并交付代码 |
-| dispatch / schedule workflow 中显式设置非空 `prompt` | 运行通用自动化 task                        |
-| `@dsh review`                                        | 手动重新 review 当前 PR                    |
-| `@dsh diagnose`                                      | 读取失败的 check 和日志，定位原因          |
-| `@dsh fix`                                           | 在受信任写模式下修改代码并运行验证         |
-| Issue 中的 `@dsh implement`                          | 理解 Issue、改代码、运行验证并创建 PR      |
-
-命令必须出现在评论第一行。可以直接复制这些 workflow：
-
-- [`examples/commands.yml`](examples/commands.yml)：`@dsh` 命令、修复和 Issue → PR
-- [`examples/ci-diagnose.yml`](examples/ci-diagnose.yml)：CI 失败诊断
-- [`examples/ci-auto-fix.yml`](examples/ci-auto-fix.yml)：受信任的 CI 自动修复
-- [`examples/task-automation.yml`](examples/task-automation.yml)：v0.5.1 基于 profile 的显式 prompt 通用自动化
-- [`examples/controlled-extensions.yml`](examples/controlled-extensions.yml)：v0.5.1 custom MCP 与 DSH Bundle/Profile 配置
-
-`fix` 和 `implement` 不会因为写了命令就自动获得权限。你还需要在 workflow 中设置 `allow-write: "true"`、保持 `run-tests: "true"`，并在 `test-commands` 中提供至少一个 argv 数组。详细输入见 [`action.yml`](action.yml)。
-
-## 通用 task 与显式自动化
-
-`task` 不把工作限制在 review、diagnose、fix 或 implement 模板内。它既能回答自然语言问题，也能阅读仓库或执行编码任务：
-
-```text
-@dsh task --read 解释这个 PR 为什么需要两阶段提交
-@dsh task --write 为解析器补上空输入测试并运行验证
-```
-
-命令必须从评论第一行开始；后续行可以继续写任务说明。`--read` 是 `task` 的默认值。`--write` 只表示请求写能力，不是授权：仍需 `allow-write: "true"`、`run-tests: "true"`、非空 validation command 列表、同仓库且非 `pull_request_target` 的上下文、所有来源 actor 通过 write/maintain/admin 检查，以及 `workspace.edit` 留在有效工具 allowlist 中。fork PR 永远不会因此升级为写模式。
-
-在 `workflow_dispatch`、`repository_dispatch` 或 `schedule` 这类自动化事件中，`command: auto` 加非空 `prompt` 会路由到通用 `task`。也可以显式设置 `command: task`；此时 `prompt` 必填。`task-access` 默认为 `read`：
-
-```yaml
-with:
-  command: auto
-  prompt: "检查依赖边界，必要时补测试并解释结果"
-  task-access: read
-```
-
-`prompt` 属于受信任 control-plane 配置，只应来自维护者写入的 workflow 或受信任的 dispatch 输入；不要把 Issue 正文、PR 内容、日志或其他不可信数据未经区分地提升为 `prompt`。同样的来源规则也适用于 capability inputs，尤其是 `permission-profile`、`allowed-tools`、`disallowed-tools`、`container-image`、`base-url`、`web-search-base-url`、`isolation` 与 `dsh-executable`：它们决定权限、worker code、凭据路由或进程边界。当前基于 profile 的完整读/写 dispatch 模板见 [`examples/task-automation.yml`](examples/task-automation.yml)。
-
-无 Issue/PR 实体的只读自动化会通过 step summary 和 outputs 返回回答。无实体或以 Issue 为目标的写 task 会创建独立 `dsh/task-*` 分支和 PR；controller 不会把通用自动化改动直接推到默认分支。PR 上获准的同仓库写 task 仍只作用于 controller 绑定并重新校验过的目标分支。
-
-## 多轮修改、验证与修复闭环
-
-v0.3 引入的 controller loop 在 v0.5.1 中仍是执行模型。它属于 Action controller，而不在 DSH shell 中；每一轮都是新的、受同一任务锚点和能力策略约束的 DSH turn：
-
-```text
-DSH turn
-  ├─ needs_tool → controller 运行一个已允许工具 → 限长/脱敏结果作为不可信反馈 → 下一轮
-  ├─ final → controller validation 失败 → stdout/stderr 作为不可信反馈 → 下一轮修改
-  ├─ final → validation 通过 → controller 发布、commit 或创建 PR
-  └─ blocked → 仅在没有未解决的 Controller validation failure 时返回 neutral
-```
-
-默认 `strict` Agent toolset 没有 shell。受信任维护者可以选择 `standard` 或精确的 `custom` 策略，在无凭据 Docker worker 内开放经过审计的 DSH 原生 Bash 工具。任何 profile 都不会让 DSH 获得 GitHub 凭据、真实 DeepSeek key、自行批准或扩大工具集合的能力，也不会获得 commit/push/PR/Release 权限。显式获准的第三方扩展属于受信任 worker code，可以产生下文说明的进程级副作用。controller 负责 validation、实际变更检查和所有最终 GitHub mutation。`max-turns`（默认 3）统一限制工具请求和 validation 修复所消耗的 DSH turn；`timeout-minutes` 是整个 controller loop 的总 deadline。若相同 workspace revision 连续得到相同 validation 失败，controller 会以 no-progress 错误停止，避免无效循环。修复轮通过返回 `blocked`、耗尽 turn 或输出畸形 structured output 都不能抹去待处理的 validation failure：原始失败与任何 Validation Integrity audit 会一直保持权威，直至后续 finalization 通过。独立的 cancellation、credential leak、isolation 与 runtime failure 仍保留各自分类。turn/tool/validation-retry 计数与限长 tool receipts 会写入 `result-json.loop`。
-
-## 权限档位
-
-多数 workflow 只需要选择一个 preset。权限档位控制沙箱内的 Agent，不授予 GitHub authority。
-
-| Profile    | 适用场景                        | 预设工具                                                                                     |
-| ---------- | ------------------------------- | -------------------------------------------------------------------------------------------- |
-| `strict`   | Review 与兼容 v0.4 的默认行为   | `workspace.read`、`workspace.search`，以及 policy 允许时的 `workspace.edit`                  |
-| `standard` | 受信任维护者的常规 Coding Agent | strict preset 加 `native.bash`、Controller-mediated `native.web-search` 和 `native.subagent` |
-| `custom`   | 精确工具、MCP、Bundle 或 Plugin | 不预设工具；显式列出每个需要的 canonical ID                                                  |
-
-`allowed-tools` 在 preset 展开后增加精确 ID；`disallowed-tools` 使用相同的精确 ID 语法，并始终优先。可用族为 `workspace.*`、`native.*`、`command.<name>`、`mcp.<server>.<tool>` 和 `plugin.<extension>.<tool>`。如果 v0.4 workflow 依赖较小的精确 allowlist，应改选 `custom`，或加入对应 deny 项，因为 allowlist 不再替换 `strict`/`standard` preset。最终结果仍要与 actor、event、trust、workspace、network、extension 和 Controller policy 取交集；任何越界请求都会 fail closed。`custom` 不是通配授权：它从空集开始，未知、不可用、遗漏或 policy 不允许的 ID 都会 fail closed。outputs 与 step summary 会报告解析后的 `permission-profile`、`effective-tools`、`network-access`、`workspace-write` 和 `trusted-extensions`。
-
-`native.web-search` 由 Controller 通过已配置的 DeepSeek web-search endpoint 中介；它不会把真实 key 暴露给 DSH，也不等于开放通用 bridge egress。`native.bash` 要求 trusted-write Docker，不能与 bridge-networked extension 共用 worker。MCP、Bundle 与 Plugin 配置属于高级 `custom` 路径，因为获准的启动代码是 trusted worker code。Agent 无法修改自己的 profile、allow/deny 列表、extension 配置或安装 gate。
-
-## 维护者定义的安全命令工具
-
-`command.*` 工具不能接收或组装模型提供的 argv。维护者在 versioned `tool-config` 中给每个命令固定完整 argv，再通过 `allowed-tools` 单独暴露其 ID：
-
-```yaml
-with:
-  permission-profile: custom
-  allowed-tools: '["workspace.read","workspace.search","workspace.edit","command.bundle-syntax"]'
-  tool-config: |
-    {
-      "schemaVersion": 1,
-      "commands": [{
-        "name": "bundle-syntax",
-        "description": "Check the bundled JavaScript syntax without installing dependencies",
-        "argv": ["node", "--check", "dist/index.js"],
-        "timeoutMinutes": 10,
-        "maxOutputBytes": 131072,
-        "maxCalls": 2,
-        "network": "none",
-        "workspaceAccess": "read"
-      }]
-    }
-```
-
-请把示例 argv 替换为仓库自己的确定命令。command tool 不接收模型参数；常见的直接 shell executable 会作为附加防线被拒绝，未定义工具、超出调用次数以及不符合当前 policy 的 network/workspace 权限也会失败。真正的安全边界是维护者固定全部 argv、模型不能追加参数，以及凭据隔离的容器。如果 workflow 把 controller 凭据插值进 command-tool 或 validation argv，输入校验会直接拒绝。命令在无 controller 凭据、固定 digest 的 hardened container 中运行；stdout/stderr 会限长和脱敏，并始终按不可信数据回送。仅把工具写进 manifest 也不会授权执行：ID 还必须出现在 `allowed-tools`，且当前 security policy 必须允许相应的 execute/write/network capability。单独的 `native.bash` 只会通过显式 `standard`/`custom` profile，并在 trusted-write Docker policy 检查后开放；它只能运行受限的前台命令，继承沙箱与凭据隔离，且不会获得提权批准。
-
-## 官方 MCP、Bundle 与 Profile 接入
-
-v0.5.1 把完整、经过审计的 DSH 依赖集从 `0.1.0-rc.8` 升级到精确固定的 `0.1.1-rc.2`，包括 `@deepseek-ai/dsh`、app-boot、官方 MCP client、Profile/Bundle 支持、原生工具及其它直接使用的 package。rc.2 复核覆盖 app-boot、Profile/Bundle/Plugin 加载、MCP、ToolRuntime、Bash、Web Search、Subagent、receipts 以及 Docker/path/timeout 行为；现有 Action inputs、outputs 与权限语义无需改变。Controller 仍生成受控 `github-action` Profile 与 Cordis patch，通过 `@deepseek-ai/dsh-app-boot@0.1.1-rc.2` 启动，而没有另造 MCP client 或 plugin loader。该路径跳过 workspace 与 `$DSH_HOME` 的 `.env` 发现，也不启用通用 CLI 的动态 user patch 监听/热加载路径。随 Action 交付的 DSH 依赖全部由 lockfile 精确固定；`latest`、semver range、浮动 Git ref 和旧式 MCP SSE 均会被拒绝。
-
-受控 root Profile 会把 Action 的机器输出协议放在 rc.2 各工具的专用 system guidance 之后，并把 JSON `operation` 字段绑定到 Controller 精确选择的操作；Agent 不能仅因任务修改文件，就把 `task` 重新解释为 `implement`。尤其是 Web Search 的 Markdown 引用只能位于 JSON 字符串字段中；root Agent 仍必须返回一个完整的 schema-v1 JSON object，operation 变更、Markdown fence、前言、尾注或独立 citation list 都会被拒绝。这个仅适用于 root 的 section 在 `native.subagent` 中为空，子代理仍向父 Agent 返回普通内容，而不是直接面对 Action 输出边界。
-
-官方 MCP client 在这里开放它实际支持的 transport：
-
-- `stdio`：command 必须是 bare executable name 或 `/workspace` 之外的绝对 container path；shell、interpreter、downloader、包管理器、Git 与 `npx` 等动态 runner 会被拒绝；`cwd` 只能是仓库内相对路径。启动获准 executable 等同于在容器内授予完整 trusted worker-code execution，而不只是注册一个 tool schema。
-- `streamable-http`：URL 必须使用 HTTP(S)，不得内嵌凭据或 fragment；server 和每个暴露工具都必须显式声明 `network`。结构化 audit 及其公开 profile digest 只公开 URL origin，不公开 pathname、query 或 headers；另一个仅供 Controller 使用的 digest 会为 runtime 复用绑定完整、已校验的配置。
-
-`mcp-config` 是严格、带版本号的 server/tool allowlist。仅定义 server 不会授权：每个可见工具还必须以 `mcp.<server-id>.<tool-id>` 出现在 `allowed-tools`。Controller 自行推导官方 DSH 的 `mcp__...` 模型侧名称，因此 prompt 不能新增 server、重命名工具或扩大权限。例如：
-
-```yaml
-with:
-  permission-profile: custom
-  allowed-tools: '["workspace.read","workspace.search","mcp.repo-index.lookup"]'
-  mcp-config: |
-    {
-      "schemaVersion": 1,
-      "servers": [{
-        "id": "repo-index",
-        "transport": "stdio",
-        "command": "/opt/dsh-extensions/bin/repository-index-mcp",
-        "args": ["--stdio"],
-        "cwd": ".",
-        "network": false,
-        "maxCalls": 8,
-        "tools": [{
-          "id": "lookup",
-          "name": "lookup",
-          "description": "Search the prebuilt repository index",
-          "permissions": ["read"],
-          "timeoutMs": 15000,
-          "maxOutputBytes": 65536,
-          "maxCalls": 4
-        }]
-      }]
-    }
-```
-
-示例 executable 特意由 image 提供：请把经过审计的 server 构建进 digest-pinned `container-image`，不要在模型 turn 中下载。任何有效 MCP、Bundle 或 plugin 工具都要求 `isolation: docker`；本地 `dsh-executable` 兼容路径不能加载扩展。`streamable-http` 形状与受控 Profile/Bundle 路径见 [`examples/controlled-extensions.yml`](examples/controlled-extensions.yml)。
-
-`plugin-config` 使用官方 Bundle/Profile 机制。每个 Bundle 或 plugin 都必须写明 package name、精确 semver 或 `git+https://github.com/...git#<40-character-commit>` source、工具清单和 network 行为。Package 工具在 Action 侧使用 `plugin.<extension-id>.<tool-id>`，在 DSH runtime 中必须以 `plugin__<extension-id>__` 开头。只有受信任 workflow 显式设置 `allow-plugin-install: "true"` 后才允许安装第三方 package；默认关闭。
-
-> 第三方 Bundle 或 plugin 会在 DSH 启动阶段执行完整的 trusted worker code。获取 package 时会禁用 NPM lifecycle script，但工具调用 allowlist 不能沙箱化 package 初始化、后台任务或直接进程 I/O。应审查 package 及其 transitive dependency graph、不可变固定 source，必要时使用专用 runner/image，并把 network/workspace access 当成在该 worker 上授权代码执行。`allow-plugin-install` 永远不能由 prompt、PR、Issue、仓库文件或模型输出推导。
-
-安装有效第三方 package 前，Controller 会快照完整的顶层 runtime package inventory。安装后会再次核对；如果任何既有 package 被删除或版本发生变化，则立即中止。随后还会单独核验已配置 extension 的 package identity 及精确 version 或 commit。
-
-所有工具类型都从同一份 Controller policy 编译，并默认 fail closed：
-
-| 限制              | 执行规则                                                                                         |
-| ----------------- | ------------------------------------------------------------------------------------------------ |
-| `read`            | 需要读取仓库能力；untrusted fork profile 不可用                                                  |
-| `workspace-write` | 需要 trusted-write、`allow-write: "true"`、同仓库 origin、actor 检查和最终 Controller validation |
-| `network`         | owner 与每个工具都必须声明，且有效 Controller policy 必须允许                                    |
-| `timeoutMs`       | 限制一次调用；同进程 plugin 取消是 cooperative，Action 总 deadline 会硬停止 DSH                  |
-| `maxOutputBytes`  | 工具结果返回模型作为不可信反馈前的序列化字节上限                                                 |
-| `maxCalls`        | 在 Controller 多轮 loop 内同时限制单工具和所属 server/package 的调用数                           |
-
-Action 自有 policy adapter 对模型路由的 DSH native tools、官方 MCP tools 和 plugin tools 调用应用正向 runtime allowlist；现有 Controller `ToolRouter` 继续执行固定 argv 的 `command.*` 工具。两条执行路径共享 Controller 解析后的 capability、limit、audit identity 与限长 receipt。这只能约束模型可路由的调用，无法约束一个已经获准、主动恶意的 stdio server、Bundle 或 plugin 在启动、后台任务或直接进程 I/O 中做什么。Agent 本身不会得到无限制 shell、`GITHUB_TOKEN`、真实 DeepSeek key 或 commit/push/PR 权限。
-
-限制前，每个可见 runtime tool 都必须属于 Controller 审计清单，且每个 selected tool 必须实际存在；配置中已声明但未列入 `allowed-tools` 的工具不要求完成注册。限制后，模型可见清单必须与 selected allowlist 完全一致。未知工具、缺失的 selected tool，以及仍暴露在 allowlist 外的 agent-scoped tool 都会 fail closed；独立的单调 ToolRuntime guard 还会拒绝任何缺少有效 Controller rule 的调用。
-
-Network 与 workspace mount 属于整个 DSH 进程，而不是单个工具。由于 extension 进程共享 Agent 的仓库视图，每个 extension tool 都必须显式声明 `read`；同一 turn 内所有有效 MCP server/package 还必须声明相同的 network 与 workspace-write 模式。trusted-read worker 只接受 read-only owner，trusted-write worker 中共同运行的每个 owner 都必须显式声明 `workspace-write`。不同模式会被拒绝，而不会被表述成并不存在的 per-tool isolation。`network: false` 表示内部 Docker network 阻止普通外部出站，并非 worker 完全没有网络路径：DSH 仍会把 `host.docker.internal` 映射到该 network 经检查得到的 IPv4 gateway，以访问 Controller 侧 LLM proxy。因此有效权限 output 会报告 `host-gateway`，而不是 `none`。该 host-gateway path 不是 port allowlist，其他 host service 是否可达由 runner firewall policy 决定，package acquisition 也会另行使用 bridge network。
-
-Profile composition、ID mapping、进程级兼容规则、receipt 形状与 deferred session 边界详见 [`docs/extension-contracts.md`](docs/extension-contracts.md)。
-
-### 兼容性
-
-默认 `strict` profile 保留 v0.4/v0.5.0 的 review、diagnose、fix、implement、auto、task、多轮、sticky comment 与 Controller-owned GitHub write 路径。原有 input 名称、scalar outputs 和 schema-v1 `result-json` envelope 保持兼容。v0.5.1 是 runtime 兼容、架构整理与稳定性版本；不加入 Session/Resume、Label/Assignee trigger、custom trigger phrase、branch template、Agent Teams、GitHub App/installer 或其它产品扩张。
-
-## 运行进度与结构化输出
-
-当一次获准的只读操作能够对应到 PR 或 Issue 时，controller 会在准备受限上下文、运行 DSH 和发布结果期间更新一条 sticky comment。写请求在全部最终 Controller validation command 成功前不会发布任何 lifecycle/status comment；通过 gate 并完成受控写入后，最终结果才可复用同一个 controller-owned v1 marker，因此不会额外制造一条“进度评论”：
-
-| 操作                | 复用的 sticky marker |
-| ------------------- | -------------------- |
-| `task`              | `task`               |
-| `review`            | `summary`            |
-| `diagnose`          | `diagnosis`          |
-| `fix` / `implement` | `write`              |
-
-成功时，详细 review、诊断或通过 validation 的写入结果会替换同一条评论。只读失败可以在这里显示稳定错误码、阶段、经过脱敏和限长的消息与下一步。若获准的 `@dsh task --write` 最终没有 repository change，Controller 不会 commit、更新 ref、创建 PR 或 Release，但仍会把 final answer 正常发布到已解析的 Issue/PR，并把 no-change 结果写入 outputs 与 step summary。被阻止的请求，或在最终 validation 前/期间失败的写请求，仍只产生 outputs 与 step summary。只有预期 numeric bot ID 发布的 marker 才会被更新，用户伪造的 marker 不会被接管。适用的生命周期评论更新是 best effort：GitHub 评论 API 暂时不可用不会遮蔽 agent、validation 或写入的真实结果。
-
-收到 `SIGTERM` 或 `SIGINT` 时，v0.5.1 会中止活跃 worker，并在 run-scoped cleanup 进行的同时立即启动一次有时间上限的 best-effort 终态更新。若随后发现权威的非取消失败，它可以纠正 provisional cancellation；终态保护也会阻止排队中的“In progress”反向覆盖结果。强制 `SIGKILL`、runner/host 丢失、进程崩溃，或 network/GitHub API 中断都可能让全部收尾代码无法运行，因此 sticky comment 仍可能停留在“In progress”。workflow concurrency 仍然重要；排查时应以 Actions conclusion 为准，不能把陈旧评论当成任务仍在运行的证明。
-
-`progress-comment` 默认是 `true`。如果不希望显示中间状态，可以关闭：
-
-```yaml
-with:
-  progress-comment: "false"
-```
-
-关闭它只会禁用 lifecycle 更新，不会关闭正常的 review 行内评论、review summary、CI diagnosis 或 fix 最终状态发布。
-
-建议让 job 的 `timeout-minutes` 比 Action 的同名输入多留几分钟；这样 DSH 内部 watchdog 能先结束 worker，并有时间写完失败 outputs、step summary 和适用的只读 sticky comment。runtime 创建/安装、extension 安装、每个 Agent turn 与 validation 实际得到的是自身上限与总执行 deadline 剩余时间中的较小值，因此 setup 不会悄悄吃完整个任务预算。cleanup 与取消评论收尾则在 outcome 或 deadline 后各自获得固定、很短的 best-effort grace：它们不会无限阻塞，但可能让实际 wall-clock 比配置的执行 deadline 略长。
-
-Action 在 success、neutral 和 failure 路径都会设置 `result-json`。这是带 `schemaVersion: 1` 的 JSON envelope，包含适用的 `status`、operation、summary、timing、policy/capabilities、permission audit、有效 extension audit、限长 tool receipts、实际 isolation report、publication 统计、controller validation 与 validation-integrity audit、write 结果、sticky comment ID 和 error。`status` 可能是 `success`、`neutral`、`failed`、`timed_out`、`validation_failed` 或 `denied`；`validation_failed` 同时覆盖无效的 DSH structured output 和 controller validation 失败，具体由 `error.code` 区分。失败对象包含稳定的 `code`、`phase`、`title`、`message`、`guidance` 和 `retryable`。
-
-所有标量 outputs 如下：
-
-| Output                     | 含义                                                                                |
-| -------------------------- | ----------------------------------------------------------------------------------- |
-| `conclusion`               | `success`、`neutral` 或 `failure`                                                   |
-| `operation`                | `task`、`review`、`diagnose`、`fix`、`implement` 或 `none`                          |
-| `summary`                  | 任意操作的校验后摘要，失败时为安全的失败摘要                                        |
-| `review-summary`           | `summary` 的向后兼容别名                                                            |
-| `findings-count`           | review 中选中的 finding 数；其他操作中为已校验的 agent finding 数                   |
-| `branch-name`              | 创建的 DSH 分支（不适用时为空）                                                     |
-| `pull-request-url`         | 创建的 PR URL（不适用时为空）                                                       |
-| `commit-sha`               | 成功 fix 创建的 commit（不适用时为空）                                              |
-| `trust`                    | `untrusted`、`trusted-read`、`trusted-write` 或尚未解析时的 `none`                  |
-| `permission-profile`       | 已解析的 `strict`、`standard`、`custom` 或 `none` Agent 权限 preset                 |
-| `effective-tools`          | 经过 preset、deny、trust 与 policy 检查后剩余精确工具的 JSON 数组                   |
-| `network-access`           | 有效 worker path：`host-gateway`、`mediated-web`、`bridge`，权限尚未解析时为 `none` |
-| `workspace-write`          | 有效 Agent 工具能否修改 disposable workspace                                        |
-| `trusted-extensions`       | Controller 批准的 MCP、Bundle 与 Plugin owner 的 JSON 数组                          |
-| `duration-ms`              | controller 总耗时，毫秒                                                             |
-| `comment-id`               | 可用时的 sticky progress/result comment ID                                          |
-| `error-code`               | 稳定失败码；成功和 neutral 时为空                                                   |
-| `error-message`            | 脱敏且限长的失败信息                                                                |
-| `extension-profile-digest` | 脱敏后有效 Profile audit 的 SHA-256 digest；不可用时为空                            |
-| `tool-receipts`            | 含限长 `controller`/`dsh` 数组及截断元数据的 JSON object                            |
-| `result-json`              | 上述 versioned JSON envelope                                                        |
-
-v0.1.0 已有的 `conclusion`、`operation`、`review-summary`、`findings-count`、`branch-name` 和 `pull-request-url` 均保留；现有 workflow 不需要改写。模型给出的 `verification` 与 controller 真正运行的 validation 是两类数据，`result-json` 会把后者单独放在 `validation` 中。
-
-失败的 Action step 也会先写 outputs；后续步骤要读取它时，请使用 `always()`，并通过环境变量传给 shell，避免把模型派生文本直接拼进脚本：
-
-```yaml
-# 先给 DeepSeek Harness step 设置 id: dsh
-- name: Inspect DSH result
-  if: ${{ always() && steps.dsh.outputs['result-json'] != '' }}
-  env:
-    DSH_RESULT_JSON: ${{ steps.dsh.outputs['result-json'] }}
-  run: printf '%s\n' "$DSH_RESULT_JSON" | jq .
-```
-
-`result-json` 中的 summary、路径和其他模型派生字符串仍然是不可信数据；这个 envelope、invocation-count state 与 receipts 都只是 telemetry，不是授权依据或防篡改安全日志。获准 extension code 与 worker 共享进程/文件系统，因此可以影响这些 telemetry；不要把输出字符串直接插入 shell 命令，也不要把它们当作独立证明。
-
-## 写模式
-
-`allow-write` 默认是 `false`。所有代码、Git ref、pull request 和写任务评论变更都要求 `run-tests: "true"`、至少一个 `test-commands` argv 数组，并且每条 validation command 成功。`run-tests: "false"` 会拒绝变更，不再是 waiver；这是 v0.4 有意引入的 breaking security hardening。在该 gate 成功或 actual-change inspection 确认 task 无变更之前，写请求不会产生 GitHub comment、commit、ref update 或 pull request；no-change task 只能发布 final answer。repository mutation 仍只对同仓库、受信任操作者开放；fork PR 始终是 review-only。测试命令使用 argv 数组，不经过 shell 展开：
-
-```yaml
-with:
-  allow-write: "true"
-  permission-profile: standard
-  run-tests: "true"
-  validation-integrity: strict
-  test-commands: '[["npm","ci","--ignore-scripts"],["npm","test"],["npm","run","typecheck"]]'
-  container-image: docker.io/library/node:24.18.0-bookworm@sha256:5711a0d445a1af54af9589066c646df387d1831a608226f4cd694fc59e745059
-```
-
-写模式和任何有效 extension 都要求使用完整的 Docker image digest。所有 image 值（包括允许 tag 的只读兼容路径）都必须是单一 Docker/OCI reference，不能以 option 开头或包含可拆分参数的空白；image 本身属于 trusted worker code。Docker 需要在 runner 上可用。
-
-### Validation 定义完整性
-
-Controller 会单独识别能够重新定义“validation 通过”含义的变更，包括 package scripts、test source/config、lint、typecheck、build config 和其它 validation entrypoint。这不会禁止代码与测试一起正常修改。
-
-- `off`：记录并报告 validation-definition changes，但不阻止。
-- `warn`：默认模式；报告变化类别与可疑的削弱信号。
-- `strict`：阻止高置信度的削弱（包括 audit 截断）；若 control-plane definition 有变化但没有明显削弱信号，则保留候选代码/测试并恢复基线 validation definitions，再执行配置好的 validation。
-
-该模式属于受信任 workflow 配置，仓库内容与模型都不能降低它。Controller 会在考虑任何 GitHub mutation 前把 audit 与处置结果写入 `result-json` 和 step summary。
-
-## 安全
-
-安全模型分成四层，避免把“操作者可信”和“仓库内容可信”混为一谈：
-
-1. **Actor / control plane**：交互式 `@dsh` 命令要求所有来源 actor 都通过 write/maintain/admin 检查；写操作还必须显式设置 `allow-write: "true"` 并通过强制 validation。`permission-profile`、精确 allow/deny 列表、`validation-integrity`、`container-image`、凭据路由 URL、`isolation`、`dsh-executable` 等 capability-bearing inputs 只能来自受信任 workflow 配置。workflow token scopes 只决定 controller 能调用哪些 GitHub API，不能绕过 actor 或 policy gate。
-2. **输入数据**：仓库文件、diff、CI 日志、README/AGENTS/CLAUDE、Issue、PR 和评论始终是不可信数据。模型输出也不直接获得权力，必须通过严格 schema、路径、大小和 marker 校验。
-3. **Worker**：`untrusted`、`trusted-read`、`trusted-write` 是 trust profile；`strict`、`standard`、`custom` 是独立的 Agent permission 维度。fork 没有仓库工具。受信任的 standard/custom worker 可以在无凭据 Docker 边界内开放经过审计的 native tools，但绝不直接访问 GitHub。
-4. **Controller / commit authority**：只有 controller 持有 GitHub client 和真实凭据，负责重新绑定 SHA/Issue/PR identity、运行无凭据 validation、检查实际文件变化，并最终评论、commit、push 或创建 PR。
-
-常用模板的 workflow permissions：
-
-| 场景                          | Workflow token permissions                                                                  |
-| ----------------------------- | ------------------------------------------------------------------------------------------- |
-| 自动或 fork PR review         | `contents: read`、`pull-requests: write`                                                    |
-| 只读通用 task                 | `contents: read`；需要 Issue/PR sticky comment 时再加对应 write scope                       |
-| 创建分支和 PR 的自动化写 task | `contents: write`、`pull-requests: write`                                                   |
-| CI diagnosis                  | `actions: read`、`checks: read`、`contents: read`、`issues: write`、`pull-requests: write`  |
-| 支持 fix / implement 的命令   | `contents: write`、`actions: read`、`checks: read`、`issues: write`、`pull-requests: write` |
-| CI auto-fix                   | 与上一行相同                                                                                |
-
-progress comment 使用与最终结果评论相同的权限，不新增 scope。`GITHUB_TOKEN` 只留在 controller；DeepSeek key 由 controller 侧代理注入，两者都不会进入 DSH prompt、workspace、MCP/Plugin 配置、worker argv/environment 或 validation 命令。输入与启动前检查会拒绝误插入的凭据，且不会在错误中回显。完整信任边界、已知限制和漏洞报告方式见 [`SECURITY.md`](SECURITY.md)。v0.5.1 只接受经过审计的 `@deepseek-ai/dsh@0.1.1-rc.2` package family 与提交的 exact lock；其他版本必须重新审查对应 policy/profile。
-
-## 架构
-
-```text
-GitHub event
-    ↓
-Action controller: route → authorize → compile permission profile + exact allow/deny
-    ↓
-只读操作的 Controller-owned sticky progress → bounded workspace / context
-    ↓
-Fresh DSH turn in Docker
-    ├─ DSH native / official MCP / Plugin tool → positive Action policy → receipt
-    ├─ needs_tool → controller fixed-argv tool ──────────────────────────┐
-    └─ final → validation + validation-integrity failure ────────────────┤ bounded untrusted feedback
-                                                                         └→ next DSH turn (max-turns/deadline)
-    ↓
-Action controller: final schema + gates → answer / commit / branch + PR
-                                      （写任务评论只会从这里开始）
-    ↓
-Action outputs: legacy scalars + versioned result-json
-```
-
-DSH worker 不持有 GitHub client。模型输出通过 schema 校验后，才由 controller 映射到 diff 行或调用已授权工具。只读 tracking comment 始终由 Controller 控制；写任务评论和所有受信任写入还必须等待最终仓库 validation 成功。受控 Profile 只会在 Controller 校验后由受信任 workflow inputs 生成；仓库内容和模型输出不能修改 MCP/Bundle/Plugin 集合。
-
-v0.5.1 保持上述外部流程，同时把 runtime 安装与 inventory audit、进程启动、Docker/network policy、Profile setup、receipt reconciliation、timeout 和 cleanup 拆成严格 run-scoped 的职责。Validation Integrity 也会先构建 normalized command graph，再规划 baseline replay。receipt 收集从上次 byte offset 继续，并使用 set-based reconciliation，避免每轮重扫完整文件，同时不改变公开 output 格式。
-
-## 核心发布 E2E
-
-永久 [Core E2E workflow](.github/workflows/e2e.yml) 必须先经过审查并单独合入默认分支，成为可信 harness。维护者随后从默认分支 dispatch，并提供完整 candidate SHA 与对应的 open、非 draft、same-repository PR 编号，同时把 `DSH_E2E_CANDIDATE_SHA` 设为完全相同的 SHA。gate 不读取任何 secret：它要求触发 actor 具有 write 权限，绑定 PR head 与默认 base，并验证 dispatch/workflow SHA 等于实时默认分支 SHA。read-only、write 与 cancellation 三个 job 全部绑定受保护的 `core-e2e` environment；写入 `DEEPSEEK_API_KEY` 前，应把该 environment 配置为只允许默认分支。
-
-harness 文件与 fixture 固定 checkout gate 输出的不可变默认分支 SHA；candidate Action code 只按独立绑定的 candidate SHA checkout，且所有 checkout 都使用 `persist-credentials: false`。no-mutation 路径会比较默认分支状态、完整 candidate identity/comments、每个 `dsh/task-*` ref 的 object type/SHA，以及 Controller task PR 的 state/draft/head/base/body。取消路径创建带 run/attempt/candidate marker 的临时 Issue，锁定唯一 bot comment ID 并验证它从 in-progress 转为 cancelled，随后严格删除该 comment 并关闭 Issue；不会复用或覆盖 candidate PR sticky comment。
-
-## Release canary
-
-轻量 [release canary](.github/workflows/release-canary.yml) 每周或手动运行，只使用 `contents: read`、一个 `strict` 只读 task，不设置矩阵或 mutation scope。其无 secret gate 要求 workflow ref 为 `refs/heads/main`，并要求 run/workflow SHA 等于实时默认分支 SHA；读取 secret 的 smoke job 与 Core E2E 一样绑定受保护、仅允许 main 的 `core-e2e` environment。发布维护者需要把 repository variable `DSH_RELEASE_CANARY_SHA` 设为小写、完整 40 字符的 commit SHA；它必须同时是正式 v0.5.1 Tag 与 GitHub Release 指向的 commit，并提供 `DEEPSEEK_API_KEY`。workflow 会先验证 Tag、非 draft/非 prerelease 的正式 Release 与该变量都解析到同一不可变 commit，再 checkout 并以本地 Action 运行。
+打开一个非 draft PR。Action 只会检出受信任的 base SHA，通过 GitHub API 读取 PR，并且不会运行 fork 中的代码。
+
+生产环境应把 `v0.5.1` 替换为该版本发布时的完整、不可变 commit SHA。权限、版本固定、安全检出规则和完整模板见[安装指南](docs/setup.zh-CN.md)。
+
+## 常用 `@dsh` 命令
+
+命令必须写在 Issue 或 PR 评论的第一行。
+
+| 命令                       | 用途                               |
+| -------------------------- | ---------------------------------- |
+| `@dsh task --read <问题>`  | 解释代码、检查仓库或回答通用问题   |
+| `@dsh task --write <任务>` | 请求编码任务；所有写入关卡仍须通过 |
+| `@dsh review`              | 重新审查当前 PR                    |
+| `@dsh diagnose`            | 诊断失败的检查和日志               |
+| `@dsh fix`                 | 在受信任写模式下修复同仓库 PR      |
+| `@dsh implement`           | 实现 Issue 并创建 PR               |
+
+`--write`、`fix` 和 `implement` 只是请求能力，并不授予权限。workflow 必须显式启用写模式，并提供由 Controller 执行的验证命令。命令和自动化用法见[使用指南](docs/usage.zh-CN.md)，完整关卡见[配置参考](docs/configuration.md)。
+
+## 安全边界
+
+- Agent 不会拿到真实的 `GITHUB_TOKEN` 或 DeepSeek key。只有 Controller 能调用 GitHub 写入 API。
+- 仓库内容、diff、Issue、PR、评论、日志、模型输出和工具输出始终是不可信数据。
+- fork 审查使用没有 `.git`、没有凭据的 worker；workflow 只能检出受信任的 base SHA，并设置 `persist-credentials: false`。
+- 写入需要受信任的同仓库上下文、通过授权检查的操作者、Docker、`allow-write: "true"`、非空固定验证命令，以及全部验证成功；受保护路径和 Validation Integrity 检查仍然有效。
+- 获准的 Bundle、Plugin 或 stdio MCP server 属于受信任的 worker code。ToolRuntime 只能限制模型路由的调用，不能沙箱化扩展启动、后台任务或直接进程 I/O。
+
+启用写模式、host 执行、网络访问或第三方扩展前，请完整阅读[安全策略](SECURITY.md)。
+
+## 文档
+
+| 指南                                                       | 内容                                                                 |
+| ---------------------------------------------------------- | -------------------------------------------------------------------- |
+| [安装指南](docs/setup.zh-CN.md) · [English](docs/setup.md) | Secret、首个 workflow、权限、安全检出和模板                          |
+| [使用指南](docs/usage.zh-CN.md) · [English](docs/usage.md) | `@dsh` 命令、task、review、diagnose、fix、implement 和自动化         |
+| [配置参考](docs/configuration.md)                          | 输入、权限档位、工具、验证、扩展和输出                               |
+| [故障排查](docs/troubleshooting.md)                        | 权限拒绝、Docker、超时、取消、验证和扩展故障                         |
+| [安全策略](SECURITY.md)                                    | 信任模型、凭据边界、网络行为和已知限制                               |
+| [扩展契约](docs/extension-contracts.md)                    | MCP、Profile、Bundle、Plugin、ToolRuntime 和 receipts 的深层技术约束 |
+| [维护者发布指南](docs/maintainer-release.md)               | 本地检查、核心 E2E、release canary、版本更新和发布                   |
+| [贡献指南](CONTRIBUTING.md) · [更新记录](CHANGELOG.md)     | 开发流程和版本历史                                                   |
 
 ## 开发
 
@@ -405,14 +121,10 @@ npm ci
 npm run check
 ```
 
-Marketplace 使用的 `dist/` 会随 release 一起提交。依赖和打包说明见 [`BUNDLED_DEPENDENCIES.md`](BUNDLED_DEPENDENCIES.md)。
+具体流程见 [CONTRIBUTING.md](CONTRIBUTING.md)。用于 GitHub Marketplace 的 `dist/` 会随版本提交，请勿手工修改。
 
-## License
+## 许可证
 
-[MIT](LICENSE)。第三方许可见 [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md)。
+本项目采用 [MIT](LICENSE) 许可证。第三方许可见 [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) 和 [BUNDLED_DEPENDENCIES.md](BUNDLED_DEPENDENCIES.md)。
 
-## Acknowledgements
-
-- [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 提供本项目使用的 headless runtime、MCP client、Bundle/Profile 加载与 Cordis 配置。
-- GitHub 事件路由、权限检查和 tracking 机制基于 [Claude Code Action](https://github.com/anthropics/claude-code-action) 的 MIT 实现适配。对应上游 commit 和许可文本记录在 [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md)。
-- Structured output 和执行/发布权限分离的设计也参考了 [Codex GitHub Action](https://learn.chatgpt.com/docs/github-action)；本项目仍保留自己的 controller/worker 信任边界与输出协议。
+DeepSeek Harness 提供 headless runtime 和官方扩展机制。GitHub 集成还参考了采用 MIT 许可证的 [Claude Code Action](https://github.com/anthropics/claude-code-action) 模式，以及 [Codex GitHub Action](https://learn.chatgpt.com/docs/github-action) 对执行权限和发布权限的分离方式；准确的来源说明记录在第三方许可文件中。

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,450 @@
+# Configuration
+
+[README](../README.md) · [Setup](setup.md) · [Usage](usage.md) · [Troubleshooting](troubleshooting.md) · [Security](../SECURITY.md)
+
+This page is the user-facing reference for Action inputs, permissions, tools,
+extensions, validation, progress reporting, and outputs. [`action.yml`](../action.yml)
+is the authoritative public interface. For the complete threat model and known
+limits, read [`SECURITY.md`](../SECURITY.md); for low-level extension behavior,
+read [Extension contracts](extension-contracts.md).
+
+Treat every capability-bearing input as trusted control-plane configuration.
+Keep these values literal in a reviewed workflow, or derive them only from a
+trusted dispatch input. Do not interpolate pull-request text, issue bodies,
+comments, CI logs, repository files, or model output into `prompt`, permission,
+validation, image, extension, executable, or credential-routing inputs.
+
+## Inputs
+
+### Credentials and API routing
+
+| Input                 | Required/default                        | Purpose                                                                                                                                                               |
+| --------------------- | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `deepseek-api-key`    | Required                                | DeepSeek API key held by the Controller-side credential proxy. It is not passed to DSH, repository code, tools, extensions, or validation.                            |
+| `github-token`        | `${{ github.token }}`                   | Token used only by the trusted Controller for authorized GitHub reads and mutations. Workflow `permissions` remain a separate gate.                                   |
+| `base-url`            | `https://api.deepseek.com`              | Trusted upstream for Controller-proxied DeepSeek chat requests. The real DeepSeek key is sent to this destination.                                                    |
+| `web-search-base-url` | `https://api.deepseek.com/anthropic/v1` | Trusted upstream for Controller-mediated DeepSeek Anthropic Messages web search. The real key is sent to this destination only when `native.web-search` is effective. |
+| `bot-user-id`         | `41898282`                              | Numeric account ID used to recognize Controller-owned sticky comments. The default is `github-actions[bot]`.                                                          |
+
+`base-url` and `web-search-base-url` are credential-routing decisions, not
+ordinary model data. Review non-default endpoints as carefully as any other
+secret recipient.
+
+### Operation and publication
+
+| Input              | Default | Accepted values and behavior                                                                                                                                |
+| ------------------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `command`          | `auto`  | `auto`, `task`, `review`, `diagnose`, `fix`, or `implement`. `auto` routes from the event; on dispatch/schedule events a non-empty `prompt` selects `task`. |
+| `task-access`      | `read`  | `read` or `write`. A write value requests a capability; it does not authorize a write.                                                                      |
+| `prompt`           | Empty   | Trusted task instructions. Required when `command: task`. See [Usage](usage.md) for event routing and command examples.                                     |
+| `allow-write`      | `false` | Enables consideration of same-repository writes after every actor, event, origin, SHA, protected-path, tool, and validation gate passes.                    |
+| `max-findings`     | `20`    | Maximum number of high-confidence findings to publish; accepted range is 1–100.                                                                             |
+| `progress-comment` | `true`  | Enables eligible read-only lifecycle updates. It does not disable normal final results or inline review comments.                                           |
+
+Writing `@dsh fix`, `@dsh implement`, or `@dsh task --write` is never enough by
+itself. An actual mutation also requires trusted origin and actors, suitable
+workflow token scopes, `run-tests: "true"`, a non-empty `test-commands` list,
+successful Controller validation, and an effective `workspace.edit` grant. A
+confirmed no-change task can publish only its answer and performs no mutation.
+
+### Runtime, isolation, and limits
+
+| Input             | Default                                       | Purpose and constraints                                                                                                                                                  |
+| ----------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `dsh-version`     | `0.1.1-rc.2`                                  | Exact audited DSH version. v0.5.1 rejects another version, ranges, and `latest`.                                                                                         |
+| `dsh-executable`  | Empty                                         | Optional absolute path to a preinstalled DSH executable. This trusted host-compatibility path has no container boundary and cannot load extensions.                      |
+| `isolation`       | `docker`                                      | `docker` or `none`. Untrusted review data, writes, and effective extensions require Docker. `none` is only for eligible trusted-read work on a dedicated trusted runner. |
+| `container-image` | Digest-pinned Node 24 image from `action.yml` | Trusted worker code. The value must be one Docker/OCI reference. Writes and effective extensions require a full `name@sha256:<64 lowercase hex>` digest.                 |
+| `timeout-minutes` | `20`                                          | Overall setup/execution deadline; accepted range is 1–360. Fixed short cleanup and cancellation-finalization grace may run afterwards.                                   |
+| `max-turns`       | `3`                                           | Maximum fresh DSH turns shared by tool requests and validation repairs; accepted range is 1–10.                                                                          |
+
+Set the job-level `timeout-minutes` a few minutes above the Action input. This
+lets the Action stop its worker, publish terminal outputs, attempt an eligible
+sticky-comment update, and clean up before GitHub terminates the whole job.
+Runtime installation, extension installation, each Agent turn, and validation
+have independent caps, each further limited by the remaining overall deadline.
+
+### Validation
+
+| Input                  | Default | Purpose                                                                                                                                                                            |
+| ---------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `run-tests`            | `true`  | Must remain `true` for every code, Git ref, pull-request, and write-task comment mutation. `false` denies the mutation; it is not a waiver.                                        |
+| `test-commands`        | `[]`    | JSON array of non-empty argv arrays, for example `[["npm","test"],["npm","run","typecheck"]]`. Every configured command must pass before a write. No shell expansion is performed. |
+| `validation-integrity` | `warn`  | `off`, `warn`, or `strict`; controls the Controller-owned audit of changes to tests, scripts, lint/typecheck/build configuration, and other validation definitions.                |
+
+Validation runs in a disposable, credential-free Docker container after all
+trusted-write gates pass. Do not place `GITHUB_TOKEN`, the DeepSeek key, or
+another Controller credential in validation argv. Replace example npm commands
+with deterministic validation commands for your repository.
+
+### Agent tools and extensions
+
+| Input                  | Default                                         | Purpose                                                                                                                            |
+| ---------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `permission-profile`   | `strict`                                        | Agent tool preset: `strict`, `standard`, or `custom`. This does not grant GitHub authority.                                        |
+| `allowed-tools`        | `[]`                                            | JSON array of exact canonical tool IDs requested in addition to preset expansion. Configuration alone does not authorize a tool.   |
+| `disallowed-tools`     | `[]`                                            | JSON array of exact canonical tool IDs. Deny always wins.                                                                          |
+| `tool-config`          | `{"schemaVersion":1,"commands":[]}`             | Versioned manifest of maintainer-owned, fixed-argv `command.*` tools.                                                              |
+| `mcp-config`           | `{"schemaVersion":1,"servers":[]}`              | Versioned allowlist for official DSH MCP servers and their tools.                                                                  |
+| `plugin-config`        | `{"schemaVersion":1,"bundles":[],"plugins":[]}` | Versioned allowlist for DSH Bundles and direct Cordis plugins.                                                                     |
+| `allow-plugin-install` | `false`                                         | Separate startup gate for an effective third-party Bundle or plugin package. Installation and startup execute trusted worker code. |
+
+All three manifests require `schemaVersion: 1`; unknown fields and unsupported
+versions fail closed. MCP, Bundle, and Plugin configuration uses the advanced
+`custom` profile path. `strict` remains accepted for v0.4 compatibility, but
+`standard` with extension configuration is rejected.
+
+## Permission model
+
+Three independent layers must agree:
+
+1. **Workflow token scopes** decide which GitHub APIs the Controller may call.
+2. **Execution trust** (`untrusted`, `trusted-read`, or `trusted-write`) comes
+   from the event, actor, origin, and bound repository identity.
+3. **Agent permissions** come from the selected preset, exact allow/deny lists,
+   declared tool requirements, and Controller policy.
+
+A broader setting in one layer cannot override a denial in another. The Agent
+never receives the real GitHub token or DeepSeek key, and only the Controller
+can comment, commit, push, update a ref, or open a pull request.
+
+### Workflow token scopes
+
+Use the smallest GitHub `permissions` block that supports the workflow:
+
+| Scenario                                    | Typical scopes                                                                              |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Automatic or fork PR review                 | `contents: read`, `pull-requests: write`                                                    |
+| Read-only task without Issue/PR publication | `contents: read`                                                                            |
+| Task that creates a branch and PR           | `contents: write`, `pull-requests: write`                                                   |
+| CI diagnosis                                | `actions: read`, `checks: read`, `contents: read`, `issues: write`, `pull-requests: write`  |
+| Commands with fix/implement, or CI auto-fix | `actions: read`, `checks: read`, `contents: write`, `issues: write`, `pull-requests: write` |
+
+These scopes let the Controller call GitHub; they do not bypass actor, fork,
+event, SHA, protected-path, extension, or validation checks. See [Setup](setup.md)
+for complete workflow templates.
+
+### Permission profiles
+
+| Profile    | Preset request                                                          | Intended use                                                                                   |
+| ---------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `strict`   | `workspace.read`, `workspace.search`, `workspace.edit`                  | Default, review, and v0.4-compatible behavior. Edit remains ineffective outside trusted write. |
+| `standard` | `strict` plus `native.bash`, `native.web-search`, and `native.subagent` | Trusted maintainer coding tasks. Bash and subagent still require trusted-write Docker policy.  |
+| `custom`   | No preset                                                               | Exact tools, command tools, MCP, Bundle, or Plugin configuration. List every tool explicitly.  |
+
+`allowed-tools` adds exact requests after preset expansion; it does not replace a
+`strict` or `standard` preset. Use `custom` for a minimal exact set. Exact
+`disallowed-tools` entries always win. The final set is intersected with trust,
+event, actor, workspace, network, extension, and Controller policy. Unknown,
+unavailable, omitted, or policy-ineligible IDs fail closed.
+
+Canonical Action tool IDs are:
+
+- `workspace.read`, `workspace.search`, and `workspace.edit`;
+- `native.bash`, `native.web-search`, and `native.subagent`;
+- `command.<name>` for Controller fixed-argv tools;
+- `mcp.<server-id>.<tool-id>` for MCP tools; and
+- `plugin.<extension-id>.<tool-id>` for Bundle or direct plugin tools.
+
+The DSH runtime may use a different model-facing name. Authorization always uses
+the canonical Action ID.
+
+### Native tools
+
+- `workspace.read` and `workspace.search` operate on the run-scoped `.git`-less
+  workspace when repository access is allowed.
+- `workspace.edit` requires effective trusted-write authority and is followed by
+  actual-change inspection and Controller validation.
+- `native.bash` is opt-in through `standard` or `custom`, requires trusted-write
+  Docker, runs bounded foreground commands without credentials, and cannot
+  share a worker with a bridge-networked extension.
+- `native.web-search` is mediated by the Controller through
+  `web-search-base-url`. It does not expose the real key, provide arbitrary URL
+  fetch, or imply general Docker bridge egress.
+- `native.subagent` is available only under eligible trusted-write policy. Its
+  ordinary response returns to the root Agent; it does not bypass the Action's
+  root structured-output contract.
+
+## Maintainer-defined command tools
+
+A `command.*` tool is a complete argv chosen by the workflow maintainer. The
+model may select the advertised tool but cannot add arguments.
+
+```yaml
+with:
+  permission-profile: custom
+  allowed-tools: '["workspace.read","workspace.search","command.bundle-syntax"]'
+  tool-config: |
+    {
+      "schemaVersion": 1,
+      "commands": [{
+        "name": "bundle-syntax",
+        "description": "Check the bundled JavaScript syntax",
+        "argv": ["node", "--check", "dist/index.js"],
+        "timeoutMinutes": 10,
+        "maxOutputBytes": 131072,
+        "maxCalls": 2,
+        "network": "none",
+        "workspaceAccess": "read"
+      }]
+    }
+```
+
+The defaults per command are a 10-minute timeout, 128 KiB output, three calls,
+no network, and read-only workspace access. Direct shell interpreters are
+rejected. A `write` mount or `bridge` network must be explicit and must survive
+the same Controller capability intersection. stdout and stderr are bounded,
+redacted, and returned to the model only as untrusted data.
+
+## MCP
+
+`mcp-config` is a strict server-and-tool allowlist for the official DSH MCP
+client. Defining a server does not grant any tool. Each selected tool must also
+appear in `allowed-tools` as `mcp.<server-id>.<tool-id>` and survive Controller
+policy.
+
+```yaml
+with:
+  permission-profile: custom
+  isolation: docker
+  allowed-tools: '["workspace.read","workspace.search","mcp.repo-index.lookup"]'
+  mcp-config: |
+    {
+      "schemaVersion": 1,
+      "servers": [{
+        "id": "repo-index",
+        "transport": "stdio",
+        "command": "/opt/dsh-extensions/bin/repository-index-mcp",
+        "args": ["--stdio"],
+        "cwd": ".",
+        "network": false,
+        "maxCalls": 8,
+        "tools": [{
+          "id": "lookup",
+          "name": "lookup",
+          "description": "Search the prebuilt repository index",
+          "permissions": ["read"],
+          "timeoutMs": 15000,
+          "maxOutputBytes": 65536,
+          "maxCalls": 4
+        }]
+      }]
+    }
+```
+
+Supported transports:
+
+- `stdio`: use a bare executable name or an absolute container path outside
+  `/workspace`. Shells, interpreters, downloaders, package managers, Git,
+  relative paths, and dynamic runners such as `npx` are rejected. Optional
+  `cwd` is repository-relative. Put the audited executable in the digest-pinned
+  image; starting it is full trusted worker-code execution.
+- `streamable-http`: use an HTTP(S) URL without embedded credentials or a
+  fragment. Put credentials in explicit headers. The server and every tool must
+  declare network permission.
+
+Each tool declares `permissions`, `timeoutMs`, `maxOutputBytes`, and `maxCalls`;
+the server has its own `maxCalls` and reconnect policy. Every extension tool
+must declare `read` because the process shares the repository view. Network and
+workspace mounts belong to the whole DSH process, so tools owned by one server
+must agree on workspace-write mode and the server's network setting. MCP results
+remain untrusted data.
+
+See [`examples/controlled-extensions.yml`](../examples/controlled-extensions.yml)
+for both configuration families and [Extension contracts](extension-contracts.md)
+for identifier normalization, inventory checks, limits, and receipt behavior.
+
+## Bundle, Plugin, and Profile loading
+
+`plugin-config` declares DSH Bundles and direct Cordis plugins. There is no
+separate user-provided Profile input: after validating trusted workflow inputs,
+the Controller generates the run-scoped `github-action` Profile and Cordis patch
+and loads only effective entries through the official DSH app-boot API.
+
+```yaml
+with:
+  permission-profile: custom
+  isolation: docker
+  allow-plugin-install: "true"
+  allowed-tools: '["workspace.read","plugin.repo-audit.scan"]'
+  plugin-config: |
+    {
+      "schemaVersion": 1,
+      "bundles": [{
+        "id": "repo-audit",
+        "package": "@example/dsh-repository-audit-bundle",
+        "source": "1.2.3",
+        "network": false,
+        "tools": [{
+          "id": "scan",
+          "name": "plugin__repo-audit__scan",
+          "description": "Run the audited repository scan",
+          "permissions": ["read"],
+          "timeoutMs": 30000,
+          "maxOutputBytes": 131072,
+          "maxCalls": 2
+        }]
+      }],
+      "plugins": []
+    }
+```
+
+Each package must use an exact semver or
+`git+https://github.com/<owner>/<repo>.git#<40-character-commit>`. `latest`,
+ranges, floating refs, and replacement of Controller-owned DSH packages are
+rejected. Direct plugin entries use the same fields and may additionally carry
+a `config` object. Package runtime names must begin with
+`plugin__<extension-id>__`; authorization uses
+`plugin.<extension-id>.<tool-id>`.
+
+`allow-plugin-install: "true"` is an independent gate; the package tool must
+still be selected and policy-eligible. Acquisition disables npm lifecycle
+scripts, then verifies the installed identity, immutable source, Bundle patch
+path, and the complete pre-existing top-level runtime package inventory.
+Package acquisition uses Docker bridge networking even if later runtime
+configuration says `network: false`.
+
+> A permitted stdio MCP server, Bundle, or plugin is trusted executable worker
+> code. ToolRuntime controls model-routed tool calls; it does **not** sandbox
+> package initialization, startup hooks, background work, or direct process I/O.
+> Review the complete package and transitive dependency graph, pin it
+> immutably, and use runner-level filesystem/network isolation appropriate for
+> trusted code.
+
+## Docker, workspace, and network
+
+- Workers use a disposable, run-scoped `.git`-less workspace. DSH home, npm
+  cache, counters, receipts, and tool state are also run-scoped.
+- The worker receives neither checkout credentials nor Controller credentials.
+  Keep `persist-credentials: false` on checkout.
+- `network: false` for extensions blocks ordinary external egress through an
+  internal Docker network, but the worker still reaches the Controller LLM proxy
+  through an inspected `host.docker.internal` gateway. This is not a port
+  allowlist; runner firewall policy protects other host services.
+- A network-enabled extension gives the co-hosted DSH process Docker bridge
+  egress. It is not a destination allowlist.
+- Network namespaces and mounts apply to the complete DSH process, not one tool.
+  All co-hosted extension owners must agree on network and workspace-write mode.
+- The validation container uses bridge networking for dependency installation.
+  Apply runner egress controls when source confidentiality or reproducibility
+  requires them.
+
+The selected `container-image` itself is trusted worker code. An immutable digest
+proves identity, not safety; review and maintain the image separately.
+
+## Write validation and integrity
+
+Every repository mutation requires all configured `test-commands` to pass in
+order. Commands are argv arrays, not shell strings, and execute without the
+GitHub token or DeepSeek key. Model-reported verification and ToolRuntime
+receipts never replace Controller validation.
+
+`validation-integrity` separately checks whether the proposed change redefines
+what “validation passed” means:
+
+- `off` records classified validation-definition changes without blocking;
+- `warn` records changed categories and suspicious weakening signals; and
+- `strict` blocks high-confidence weakening and truncated audits. For other
+  control-plane changes it reruns configured validation against candidate code
+  with the bound baseline validation definitions restored.
+
+Changing tests with an implementation is allowed. The Agent cannot lower this
+mode, approve an integrity finding, or replace the audit with its own claim.
+Validation and integrity must both pass before the Controller performs any
+GitHub mutation.
+
+## Progress comments
+
+For an authorized read-only operation attached to a pull request or issue, the
+Controller can reuse one bot-owned sticky marker while work progresses and when
+it publishes the result:
+
+| Operation           | Marker      |
+| ------------------- | ----------- |
+| `task`              | `task`      |
+| `review`            | `summary`   |
+| `diagnose`          | `diagnosis` |
+| `fix` / `implement` | `write`     |
+
+Write requests publish no lifecycle/status comment until final validation
+succeeds, or until actual-change inspection confirms a no-change task. A
+no-change write can publish its final answer but creates no commit, ref, pull
+request, or release mutation. `progress-comment: "false"` disables intermediate
+lifecycle updates only.
+
+Comment updates are best effort. `SIGTERM` and `SIGINT` trigger a bounded
+cancellation update, but `SIGKILL`, runner/host loss, process crashes, and
+GitHub API outages can prevent finalization and leave “In progress” stale. The
+Actions run conclusion is authoritative. Preserve per-target workflow
+`concurrency` to prevent older runs from overwriting newer sticky state.
+
+## Outputs
+
+The Action writes outputs on success, neutral completion, and failure paths.
+
+| Output                     | Meaning                                                                                                                      |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `conclusion`               | `success`, `neutral`, or `failure`.                                                                                          |
+| `operation`                | Resolved `task`, `review`, `diagnose`, `fix`, `implement`, or `none`.                                                        |
+| `summary`                  | Validated final summary for any operation, or a safe failure summary.                                                        |
+| `review-summary`           | Backward-compatible alias of `summary`.                                                                                      |
+| `findings-count`           | Selected review findings, or validated Agent findings for another operation.                                                 |
+| `branch-name`              | Created or updated `dsh` branch; empty when not applicable.                                                                  |
+| `pull-request-url`         | Created pull request URL; empty when not applicable.                                                                         |
+| `commit-sha`               | Commit created by a successful fix; empty when not applicable.                                                               |
+| `trust`                    | Resolved `untrusted`, `trusted-read`, `trusted-write`, or `none` execution trust.                                            |
+| `permission-profile`       | Resolved `strict`, `standard`, `custom`, or `none` Agent profile.                                                            |
+| `effective-tools`          | JSON array left after preset, deny, trust, extension, and policy intersection.                                               |
+| `network-access`           | Effective `host-gateway`, `mediated-web`, `bridge`, or unresolved `none` worker path.                                        |
+| `workspace-write`          | Whether the effective Agent tools can modify the disposable workspace.                                                       |
+| `trusted-extensions`       | JSON array of Controller-approved MCP, Bundle, and Plugin owners loaded for the run.                                         |
+| `duration-ms`              | Total Controller duration in milliseconds.                                                                                   |
+| `comment-id`               | Sticky progress/result comment ID when tracking was available.                                                               |
+| `error-code`               | Stable failure code; empty on success or neutral completion.                                                                 |
+| `error-message`            | Redacted and bounded failure message.                                                                                        |
+| `extension-profile-digest` | SHA-256 digest of the redacted Controller-generated extension audit Profile; empty when unavailable.                         |
+| `tool-receipts`            | JSON object with bounded Controller/DSH receipt arrays and truncation metadata. Receipts are telemetry, never authorization. |
+| `result-json`              | Versioned structured envelope described below.                                                                               |
+
+The older scalar outputs remain available. A missing branch, commit, PR, or
+comment value is often expected for read-only, denied, failed, entity-free, or
+no-change outcomes.
+
+### `result-json`
+
+`result-json` is a `schemaVersion: 1` envelope containing the applicable status,
+operation, summary, policy and permission audit, effective extension audit,
+bounded receipts, loop timing/counts, actual isolation report, publication,
+Controller validation, validation integrity, write result, comment ID, and
+error. `status` is one of `success`, `neutral`, `failed`, `timed_out`,
+`validation_failed`, or `denied`. Inspect `error.code` and `error.phase` for the
+specific cause.
+
+Failed steps set outputs before failing. Read them from a later `always()` step
+without interpolating model-derived text into a shell command:
+
+```yaml
+- uses: Lixiaoyiao/deepseek-harness-action@v0.5.1
+  id: dsh
+  with:
+    deepseek-api-key: ${{ secrets.DEEPSEEK_API_KEY }}
+
+- name: Inspect DSH result
+  if: ${{ always() && steps.dsh.outputs['result-json'] != '' }}
+  env:
+    DSH_RESULT_JSON: ${{ steps.dsh.outputs['result-json'] }}
+  run: printf '%s\n' "$DSH_RESULT_JSON" | jq .
+```
+
+Model-derived summaries, paths, receipts, and extension telemetry remain
+untrusted data. Do not splice them into commands or treat `result-json`, a
+receipt, or the public extension digest as a tamper-proof security log or an
+authorization decision.
+
+## See also
+
+- [Setup](setup.md)
+- [Usage](usage.md)
+- [Troubleshooting](troubleshooting.md)
+- [Extension contracts](extension-contracts.md)
+- [Security policy](../SECURITY.md)

--- a/docs/extension-contracts.md
+++ b/docs/extension-contracts.md
@@ -1,5 +1,7 @@
 # Extension contracts
 
+[README](../README.md) · [Configuration](configuration.md) · [Troubleshooting](troubleshooting.md) · [Security](../SECURITY.md)
+
 ## Status in v0.5.1
 
 The extension model introduced in v0.4 remains active in v0.5.1 through DeepSeek Harness's

--- a/docs/maintainer-release.md
+++ b/docs/maintainer-release.md
@@ -1,0 +1,163 @@
+# Maintainer release guide
+
+[README](../README.md) · [Contributing](../CONTRIBUTING.md) · [Security](../SECURITY.md) · [Changelog](../CHANGELOG.md)
+
+This guide is for repository maintainers qualifying and publishing an Action release. A successful run proves only the exact commit SHA it tested. After any candidate change, repeat every required check against the new latest SHA.
+
+## Release invariants
+
+- Work from the latest `main`; the release tag and GitHub Release must ultimately resolve to the same immutable commit.
+- Keep the Action version, DSH version, package manifest/lock, metadata, examples, documentation, canary, and committed `dist/` aligned.
+- Never hand-edit `dist/`. Build it from source and review the generated diff.
+- Keep every directly used `@deepseek-ai/dsh*` package exactly pinned. Do not use `latest`, ranges, floating Git refs, mixed package-family versions, or peer/lock bypass flags.
+- Keep Action checkouts pinned with `persist-credentials: false`.
+- Keep the real GitHub token and DeepSeek key outside the Agent, repository code, validation, and extensions.
+- A published tag is immutable. If its formal smoke fails, do not move the tag; fix forward with the next patch release.
+
+The release constants and direct DSH package inventory live in [`src/release.ts`](../src/release.ts). [`scripts/verify-release-contract.mjs`](../scripts/verify-release-contract.mjs) checks them against the manifest, lock, Action metadata, CI runtime smoke, and release canary.
+
+## Repository environments and variables
+
+Before qualification, configure the `core-e2e` environment:
+
+1. Limit deployment to the default branch.
+2. Add `DEEPSEEK_API_KEY` to that environment.
+3. Do not expose the secret to the gate jobs; the workflows bind trusted identities before entering the environment.
+
+Core E2E uses repository variable `DSH_E2E_CANDIDATE_SHA`. The release canary uses `DSH_RELEASE_CANARY_SHA`. Each must be a lowercase, full 40-character commit SHA for its current purpose.
+
+## Local qualification
+
+Use Node.js 24 and a clean dependency installation:
+
+```bash
+npm ci
+npm run check
+```
+
+`npm run check` runs formatting, lint, type checking, coverage tests, the release-contract check, the DSH configuration audit, and a deterministic `dist` build comparison. Do not skip a failing sub-check.
+
+Before committing, inspect the complete diff and confirm that only intended source, test, metadata, documentation, and generated bundle changes are present. For a documentation-only PR, verify explicitly that `src/`, `dist/`, runtime assets, `action.yml`, and package files did not change.
+
+## Version and DSH update checklist
+
+For an Action version bump, update every release surface together:
+
+1. `ACTION_VERSION` / `ACTION_TAG` in `src/release.ts`.
+2. `package.json` and the root versions in `package-lock.json`.
+3. Release references in `action.yml`, README files, examples, and `CHANGELOG.md`.
+4. The release canary workflow name and `RELEASE_TAG`.
+5. `dist/`, generated through the normal build.
+6. Any release-specific verification fixture or documentation.
+
+For a DSH version bump, additionally:
+
+1. Confirm the complete official npm package family is published and that ordinary `npm ci` succeeds with peer and lock validation intact.
+2. Update `DSH_VERSION` and every package in `DIRECT_DSH_PACKAGES` to the same exact version, then regenerate the lock normally.
+3. Audit the real upstream change range for app-boot, Profile/Bundle/Plugin composition, MCP, ToolRuntime, Bash, Web Search, Subagent, receipts, Docker/path/timeout handling, and the bundled Action entrypoint.
+4. Revalidate the controlled Profile, native tool inventory, permission intersections, credential routing, extension locks, runtime reuse, receipts, and cleanup boundaries.
+5. Add compatibility and security regression coverage before running the real golden paths.
+
+If the official package family is incomplete or clean `npm ci` cannot consume it, do not use `--legacy-peer-deps`, mix versions, or weaken the lock audit. Leave the current exact DSH pin in place and defer the upgrade.
+
+## Pull request and candidate CI
+
+1. Create a focused release branch from the latest `main`.
+2. Run the local qualification commands.
+3. Commit and push all source, test, documentation, metadata, lock, and generated `dist` changes together as applicable.
+4. Open a PR to `main` and let [CI](../.github/workflows/ci.yml) run on the latest PR head.
+5. Resolve every failure. Any new commit invalidates the old CI result; wait for CI on the new head.
+
+Record the exact candidate identity:
+
+```bash
+candidate_sha="$(gh pr view "$pr_number" --json headRefOid --jq .headRefOid)"
+test "${#candidate_sha}" -eq 40
+```
+
+The candidate PR must be open, non-draft, same-repository, and target the default branch.
+
+## Core E2E
+
+The permanent [Core E2E workflow](../.github/workflows/e2e.yml) is trusted release harness code and must already exist on the live default branch. Its secretless gate requires a write-capable actor and binds all of the following before any secret-bearing job starts:
+
+- the workflow and dispatch SHA equal the live default-branch SHA;
+- `candidate_sha` is the current full PR head SHA;
+- `DSH_E2E_CANDIDATE_SHA` equals that SHA; and
+- the supplied PR is open, non-draft, same-repository, and based on the default branch.
+
+Set the candidate variable, then dispatch the trusted workflow from `main`:
+
+```bash
+gh variable set DSH_E2E_CANDIDATE_SHA --body "$candidate_sha"
+gh workflow run e2e.yml --ref main \
+  -f candidate_sha="$candidate_sha" \
+  -f pull_request="$pr_number"
+```
+
+Harness files and fixtures are checked out at the trusted default-branch SHA. Candidate Action code is checked out separately at the bound candidate SHA. Every checkout sets `persist-credentials: false`, and the workflow verifies that no checkout Git credential remains.
+
+The golden paths cover:
+
+| Area                        | Required evidence                                                                                                                                        |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Strict read-only            | Controlled `github-action` Profile and official Bundle identity with no write capability                                                                 |
+| MCP                         | Real Streamable HTTP allow and deny paths plus bounded receipts                                                                                          |
+| Web Search                  | Real Controller-mediated Web Search without exposing the real key                                                                                        |
+| Validation Integrity        | Strict weakening denial with no GitHub mutation                                                                                                          |
+| Ordinary validation failure | Failure with no comment, commit, ref, or PR mutation                                                                                                     |
+| Subagent                    | Real `native.subagent` through a successful no-change write path                                                                                         |
+| Bash trusted write          | `standard` native Bash, validation, and exact branch/PR/commit/file assertions                                                                           |
+| Cancellation                | Graceful `SIGTERM` moves the isolated sticky comment from In progress to cancelled, then removes only the fixture comment and closes its temporary Issue |
+| Credential isolation        | All candidate and harness checkouts use `persist-credentials: false` and have no residual Git auth configuration                                         |
+
+The workflow also compares `main`, the candidate PR, comments, `dsh/task-*` refs, and Controller-created task PRs on no-mutation paths, then revalidates the candidate identity at the end.
+
+Graceful cancellation is the verifiable path. `SIGKILL`, runner/host loss, a process crash, or GitHub API/network loss can prevent all finalizers from running; Core E2E must not claim otherwise.
+
+If Core E2E finds a bug, fix it on the PR, obtain the new head SHA, update the variable, rerun CI, and dispatch Core E2E again. Never use an older candidate run as evidence for the new head.
+
+## Merge and qualify `main`
+
+After candidate CI and Core E2E pass:
+
+1. Reconfirm the PR head SHA has not moved.
+2. Merge the PR into `main`.
+3. Record the resulting full `main` SHA.
+4. Wait for the `push` CI run on that exact `main` SHA.
+5. Verify the working tree and release metadata contain the expected version and generated bundle.
+
+Do not tag while the final `main` CI is pending or failing.
+
+## Tag and GitHub Release
+
+Create the release tag at the qualified `main` commit. An annotated tag is preferred because the canary deliberately resolves either annotated or lightweight tags to their final commit.
+
+```bash
+git tag -a "vX.Y.Z" "$release_sha" -m "vX.Y.Z"
+git push origin "vX.Y.Z"
+gh release create "vX.Y.Z" --verify-tag --title "vX.Y.Z" --notes-file release-notes.md
+```
+
+Release notes should summarize user-visible changes, security implications, compatibility, tests/E2E, performance evidence, and known limitations. Confirm the GitHub Release is neither draft nor prerelease unless that status is intentional for a non-final release.
+
+## Release canary and formal tag smoke
+
+The [release canary](../.github/workflows/release-canary.yml) runs every Wednesday at 05:17 UTC and can also be dispatched manually. Its secretless gate requires:
+
+- `refs/heads/main`;
+- the run SHA and workflow SHA to equal live `main`; and
+- `main` to remain the default branch.
+
+The protected `core-e2e` smoke job then checks that the configured release Tag, its non-draft/non-prerelease GitHub Release, and `DSH_RELEASE_CANARY_SHA` all resolve to the same commit. It checks out that immutable commit with `persist-credentials: false` and runs one `strict`, read-only, no-tools task with no mutation scope.
+
+Set the variable to the formal tag's final commit and dispatch from `main`:
+
+```bash
+gh variable set DSH_RELEASE_CANARY_SHA --body "$release_sha"
+gh workflow run release-canary.yml --ref main
+```
+
+Wait for the run and record its URL and conclusion. A successful PR candidate run or `main` CI does not replace this formal-tag smoke.
+
+If the smoke fails after publication, keep the tag immutable. Diagnose the failure, prepare the next patch release from `main`, and repeat the complete latest-SHA qualification flow.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,157 @@
+# Setup
+
+[中文](setup.zh-CN.md) · [README](../README.md) · [Usage](usage.md) · [Configuration](configuration.md)
+
+This guide takes you from a repository secret to a safe first workflow. Start with read-only pull request review, then add commands or write mode only when the repository needs them.
+
+## Requirements
+
+- A GitHub repository where you can add Actions secrets and workflows.
+- A DeepSeek API key.
+- An Ubuntu GitHub-hosted runner, or a self-hosted runner with Docker available.
+- Node.js 24 only when developing this Action itself; consumers do not install Node separately.
+
+Docker is required for untrusted pull request data, all writes, and all MCP, Bundle, or Plugin extensions. The optional host execution path has no operating-system isolation and is for dedicated trusted runners only.
+
+## 1. Add the API key
+
+Open **Settings → Secrets and variables → Actions → New repository secret** and create:
+
+```text
+DEEPSEEK_API_KEY
+```
+
+Pass it only to the `deepseek-api-key` input. Do not expose it through `env`, a prompt, validation command, MCP configuration, or Plugin configuration. The Action keeps the real key in a Controller-side proxy; the DSH worker receives only an ephemeral proxy token.
+
+The default `github-token` is `${{ github.token }}` and is also Controller-only. Keep checkout credentials disabled so repository code and the worker cannot inherit Git credentials.
+
+## 2. Choose an Action reference
+
+The examples use the current release tag for readability:
+
+```yaml
+uses: Lixiaoyiao/deepseek-harness-action@v0.5.1
+```
+
+For production, replace the tag with the full immutable commit SHA published for that release. Do not use `main`, `latest`, a version range, or another floating ref. Keep `dsh-version` at the Action's audited exact value:
+
+```yaml
+with:
+  dsh-version: 0.1.1-rc.2
+```
+
+The Action rejects a different DSH version until that package family and its Profile/tool surface have been reviewed and released together.
+
+## 3. Add safe automatic pull request review
+
+Create `.github/workflows/dsh-review.yml`:
+
+```yaml
+name: DSH review
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: dsh-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout trusted base only
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+          fetch-depth: 1
+      - uses: Lixiaoyiao/deepseek-harness-action@v0.5.1
+        with:
+          deepseek-api-key: ${{ secrets.DEEPSEEK_API_KEY }}
+          dsh-version: 0.1.1-rc.2
+```
+
+`pull_request_target` can access secrets and a privileged token, so this workflow checks out only the immutable trusted base SHA. The Action obtains the pull request diff and changed-file context through GitHub APIs; it does not check out or execute the fork revision. Preserve `persist-credentials: false`.
+
+Open a non-draft pull request and inspect the Actions run, review summary, and any inline findings. The full maintained template is [`examples/fork-review.yml`](../examples/fork-review.yml).
+
+## 4. Grant only the GitHub permissions the entry point needs
+
+Agent permission profiles do not grant GitHub permissions. The workflow token scopes only determine which APIs the trusted Controller can call.
+
+| Scenario                                      | Workflow permissions                                                                        |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Automatic or fork PR review                   | `contents: read`, `pull-requests: write`                                                    |
+| Read-only task without an Issue/PR comment    | `contents: read`                                                                            |
+| Read-only task with an Issue/PR sticky result | `contents: read` plus the matching `issues: write` or `pull-requests: write`                |
+| CI diagnosis                                  | `actions: read`, `checks: read`, `contents: read`, `issues: write`, `pull-requests: write`  |
+| Commands with fix or implement enabled        | `actions: read`, `checks: read`, `contents: write`, `issues: write`, `pull-requests: write` |
+| CI auto-fix                                   | The same permissions as the preceding row                                                   |
+| Automation that creates a branch and PR       | `contents: write`, `pull-requests: write`                                                   |
+
+A broad workflow token cannot bypass actor, event, origin, SHA, protected-path, validation, or Controller policy checks. Conversely, missing token scopes can stop an otherwise authorized result from being published.
+
+## 5. Add commands, CI, or automation
+
+Copy the template that matches the desired entry point:
+
+- [`examples/commands.yml`](../examples/commands.yml): `@dsh` task, review, diagnose, fix, and Issue implementation.
+- [`examples/ci-diagnose.yml`](../examples/ci-diagnose.yml): diagnose a failed CI run without changing code.
+- [`examples/ci-auto-fix.yml`](../examples/ci-auto-fix.yml): trusted CI repair with mandatory validation.
+- [`examples/task-automation.yml`](../examples/task-automation.yml): a maintainer-authored dispatch task with read or write access.
+- [`examples/controlled-extensions.yml`](../examples/controlled-extensions.yml): advanced custom Profile, MCP, and Bundle configuration.
+
+For `issue_comment`, `workflow_run`, dispatch, and schedule workflows, run the workflow definition from the trusted default branch. Check out the bound trusted branch or SHA, always set `persist-credentials: false`, and keep capability-bearing inputs literal or derived only from trusted workflow configuration.
+
+The `prompt` input is trusted instruction. Do not interpolate Issue bodies, PR text, comments, logs, repository files, or model output into it. GitHub resolves expressions before the Action starts, so the Action cannot recover the original provenance.
+
+## 6. Enable write mode deliberately
+
+A write command alone does not authorize mutation. A valid write workflow must also meet the actor, event, same-repository, branch, SHA, workspace, and tool policy checks, and must configure Controller-run validation:
+
+```yaml
+with:
+  permission-profile: standard
+  allow-write: "true"
+  run-tests: "true"
+  validation-integrity: strict
+  test-commands: >-
+    [
+      ["npm","ci","--ignore-scripts"],
+      ["npm","test"],
+      ["npm","run","typecheck"]
+    ]
+  container-image: docker.io/library/node:24.18.0-bookworm@sha256:5711a0d445a1af54af9589066c646df387d1831a608226f4cd694fc59e745059
+```
+
+Replace these validation commands with the commands for your repository. Each entry is a fixed argv array and is not expanded by a shell. Every command must pass. `run-tests: "false"` denies the write; it is not a waiver.
+
+The Docker image is executable worker code. Writes and extensions require a full digest, not only a tag. See [Configuration](configuration.md#write-validation-and-integrity) before enabling this path.
+
+## Checkout, timeout, and concurrency rules
+
+- Keep every `actions/checkout` reference pinned and set `persist-credentials: false`.
+- For `pull_request_target`, check out only `github.event.pull_request.base.sha`; never run the fork checkout.
+- Use a concurrency group scoped to the PR, Issue, upstream run, or automation target. The sticky marker does not contain run/head freshness data, so serialization prevents an older run from overwriting newer status.
+- Keep the job-level `timeout-minutes` a few minutes above the Action's `timeout-minutes` input. The Action needs a short bounded window to stop its worker, write outputs, and attempt eligible cancellation status updates.
+- A forced runner termination can bypass all cleanup. Treat the Actions conclusion as authoritative; see [Troubleshooting](troubleshooting.md#cancellation-or-a-sticky-comment-remains-in-progress).
+
+## Verify the installation
+
+After the first run, check that:
+
+1. Checkout reports `persist-credentials: false` and the expected trusted SHA.
+2. The Action resolves `dsh-version` to `0.1.1-rc.2`.
+3. A read-only review reports no workspace write capability.
+4. Only the intended Controller-owned summary comment and inline findings appear.
+5. The step summary and `result-json` show the expected operation, permission profile, effective tools, and network path.
+
+Next, read [Usage](usage.md) for commands and [Configuration](configuration.md) for every input, permission boundary, and output.

--- a/docs/setup.zh-CN.md
+++ b/docs/setup.zh-CN.md
@@ -1,0 +1,157 @@
+# 安装与接入
+
+[English](setup.md) · [项目首页](../README.zh-CN.md) · [使用指南](usage.zh-CN.md) · [配置参考](configuration.md)
+
+本指南从添加仓库 Secret 开始，带你建立第一个安全 workflow。建议先启用只读 PR 审查；只有仓库确实需要时，再加入命令或写模式。
+
+## 准备条件
+
+- 你能在目标 GitHub 仓库中添加 Actions Secret 和 workflow。
+- 一个 DeepSeek API key。
+- GitHub 托管的 Ubuntu runner，或已经安装 Docker 的自托管 runner。
+- 只有开发这个 Action 本身时才需要 Node.js 24；Action 使用方不用单独安装 Node.js。
+
+处理不可信 PR 数据、执行任何写入，以及使用任何 MCP、Bundle 或 Plugin 扩展时，都必须使用 Docker。可选的 host 执行路径没有操作系统隔离，只适合专用的受信任 runner。
+
+## 1. 添加 API key
+
+打开 **Settings → Secrets and variables → Actions → New repository secret**，创建：
+
+```text
+DEEPSEEK_API_KEY
+```
+
+只把它传给 `deepseek-api-key` 输入。不要通过 `env`、prompt、验证命令、MCP 配置或 Plugin 配置暴露它。Action 会把真实 key 留在 Controller 侧代理中，DSH worker 只会拿到临时代理令牌。
+
+默认的 `github-token` 是 `${{ github.token }}`，也只由 Controller 使用。请禁用 checkout 凭据，避免仓库代码或 worker 继承 Git 凭据。
+
+## 2. 选择 Action 版本
+
+为了便于阅读，示例使用当前发布 Tag：
+
+```yaml
+uses: Lixiaoyiao/deepseek-harness-action@v0.5.1
+```
+
+生产环境应把 Tag 替换为该版本发布时的完整、不可变 commit SHA。不要使用 `main`、`latest`、版本范围或其它浮动 ref。`dsh-version` 必须保持为本版本审计过的精确值：
+
+```yaml
+with:
+  dsh-version: 0.1.1-rc.2
+```
+
+只有新的 DSH package family、Profile 和工具面完成复核并随新版本发布后，Action 才会接受不同版本。
+
+## 3. 添加安全的自动 PR 审查
+
+创建 `.github/workflows/dsh-review.yml`：
+
+```yaml
+name: DSH review
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: dsh-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout trusted base only
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+          fetch-depth: 1
+      - uses: Lixiaoyiao/deepseek-harness-action@v0.5.1
+        with:
+          deepseek-api-key: ${{ secrets.DEEPSEEK_API_KEY }}
+          dsh-version: 0.1.1-rc.2
+```
+
+`pull_request_target` 可以访问 Secret 和权限较高的 token，因此这个 workflow 只检出不可变、受信任的 base SHA。Action 通过 GitHub API 获取 PR diff 和变更文件上下文，不会检出或运行 fork revision。请保留 `persist-credentials: false`。
+
+打开一个非 draft PR，检查 Actions 运行、审查汇总和行内问题。完整且持续维护的模板见 [`examples/fork-review.yml`](../examples/fork-review.yml)。
+
+## 4. 只授予入口真正需要的 GitHub 权限
+
+Agent 权限档位不会授予 GitHub 权限。workflow token scope 只决定受信任 Controller 可以调用哪些 API。
+
+| 场景                              | Workflow 权限                                                                               |
+| --------------------------------- | ------------------------------------------------------------------------------------------- |
+| 自动或 fork PR 审查               | `contents: read`、`pull-requests: write`                                                    |
+| 不需要 Issue/PR 评论的只读 task   | `contents: read`                                                                            |
+| 需要 Issue/PR 结果评论的只读 task | `contents: read`，再增加对应的 `issues: write` 或 `pull-requests: write`                    |
+| CI 诊断                           | `actions: read`、`checks: read`、`contents: read`、`issues: write`、`pull-requests: write`  |
+| 允许 fix 或 implement 的命令      | `actions: read`、`checks: read`、`contents: write`、`issues: write`、`pull-requests: write` |
+| CI 自动修复                       | 与上一行相同                                                                                |
+| 创建分支和 PR 的自动化任务        | `contents: write`、`pull-requests: write`                                                   |
+
+较宽的 workflow token 不能绕过 actor、事件、来源、SHA、受保护路径、验证或 Controller 策略。反过来，缺少必要 scope 也会让本来获准的结果无法发布。
+
+## 5. 添加命令、CI 或自动化流程
+
+按使用场景复制模板：
+
+- [`examples/commands.yml`](../examples/commands.yml)：`@dsh` task、review、diagnose、fix 和 Issue 实现。
+- [`examples/ci-diagnose.yml`](../examples/ci-diagnose.yml)：诊断失败的 CI，不修改代码。
+- [`examples/ci-auto-fix.yml`](../examples/ci-auto-fix.yml)：带强制验证的受信任 CI 修复。
+- [`examples/task-automation.yml`](../examples/task-automation.yml)：由维护者发起、可选只读或写入的 dispatch task。
+- [`examples/controlled-extensions.yml`](../examples/controlled-extensions.yml)：高级 custom Profile、MCP 和 Bundle 配置。
+
+对于 `issue_comment`、`workflow_run`、dispatch 和 schedule workflow，应从受信任的默认分支运行 workflow 定义。检出已经绑定的受信任分支或 SHA，始终设置 `persist-credentials: false`，并确保带权限含义的输入只使用字面值，或只从受信任 workflow 配置推导。
+
+`prompt` 输入属于受信任指令。不要把 Issue 正文、PR 内容、评论、日志、仓库文件或模型输出插入其中。GitHub 会在 Action 启动前解析表达式，Action 无法恢复这些值原来的来源。
+
+## 6. 谨慎启用写模式
+
+写命令本身不会授权变更。有效的写 workflow 还必须通过 actor、事件、同仓库、分支、SHA、workspace 和工具策略检查，并配置由 Controller 执行的验证：
+
+```yaml
+with:
+  permission-profile: standard
+  allow-write: "true"
+  run-tests: "true"
+  validation-integrity: strict
+  test-commands: >-
+    [
+      ["npm","ci","--ignore-scripts"],
+      ["npm","test"],
+      ["npm","run","typecheck"]
+    ]
+  container-image: docker.io/library/node:24.18.0-bookworm@sha256:5711a0d445a1af54af9589066c646df387d1831a608226f4cd694fc59e745059
+```
+
+请把这些验证命令换成适合你仓库的命令。每一项都是固定 argv 数组，不会经过 shell 展开；所有命令都必须成功。`run-tests: "false"` 会拒绝写入，不是跳过验证的开关。
+
+Docker image 本身就是可执行的 worker code。写入和扩展必须使用完整 digest，不能只固定 Tag。启用前请阅读[写模式与验证](configuration.md#write-validation-and-integrity)。
+
+## Checkout、超时与并发规则
+
+- 固定每个 `actions/checkout` 版本，并设置 `persist-credentials: false`。
+- 使用 `pull_request_target` 时，只检出 `github.event.pull_request.base.sha`，绝不运行 fork checkout。
+- 按 PR、Issue、上游 run 或自动化目标设置 concurrency group。sticky marker 不包含 run/head 新鲜度信息，因此必须串行化，避免旧运行覆盖新状态。
+- job 的 `timeout-minutes` 应比 Action 的同名输入多留几分钟，让 Action 有一个短且有上限的窗口停止 worker、写入 outputs，并尝试发布适用的取消状态。
+- runner 被强制终止时可能完全跳过 cleanup。应以 Actions conclusion 为准，详见[评论一直显示 In progress](troubleshooting.md#cancellation-or-a-sticky-comment-remains-in-progress)。
+
+## 验证接入结果
+
+第一次运行后，确认：
+
+1. Checkout 显示 `persist-credentials: false`，且检出的是预期受信任 SHA。
+2. Action 把 `dsh-version` 解析为 `0.1.1-rc.2`。
+3. 只读审查没有 workspace 写能力。
+4. 只出现预期的 Controller-owned 汇总评论和行内问题。
+5. step summary 与 `result-json` 中的 operation、权限档位、有效工具和网络路径符合预期。
+
+接下来可阅读[使用指南](usage.zh-CN.md)了解命令，阅读[配置参考](configuration.md)了解全部输入、权限边界和输出。

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,425 @@
+# Troubleshooting
+
+[README](../README.md) · [Setup](setup.md) · [Usage](usage.md) · [Configuration](configuration.md) · [Security](../SECURITY.md)
+
+Start with the GitHub Actions run, not the model's prose or a sticky comment.
+The Action conclusion is authoritative. On every terminal path, also check the
+step summary and the outputs documented in [Configuration](configuration.md).
+
+Give the Action step an `id`, then inspect `result-json` even when the step
+fails:
+
+```yaml
+- uses: Lixiaoyiao/deepseek-harness-action@v0.5.1
+  id: dsh
+  with:
+    deepseek-api-key: ${{ secrets.DEEPSEEK_API_KEY }}
+
+- name: Inspect DSH result
+  if: ${{ always() && steps.dsh.outputs['result-json'] != '' }}
+  env:
+    DSH_RESULT_JSON: ${{ steps.dsh.outputs['result-json'] }}
+  run: printf '%s\n' "$DSH_RESULT_JSON" | jq .
+```
+
+Useful fields are:
+
+- `status`: broad outcome (`denied`, `timed_out`, `validation_failed`, and so on);
+- `error.code`: stable specific classification;
+- `error.phase`: `configuration`, `routing`, `authorization`, `context`,
+  `agent`, `validation`, `publication`, or `write`;
+- `error.message` and `error.guidance`: redacted, bounded diagnostics;
+- `permissions`, `isolation`, `validation`, `validationIntegrity`, and `loop`:
+  Controller evidence for the effective run; and
+- scalar `trust`, `permission-profile`, `effective-tools`, `network-access`,
+  `workspace-write`, `error-code`, and `error-message`: convenient summaries.
+
+`result-json`, model text, and receipts are observability data, not
+authorization or tamper-proof security evidence. Keep their strings in data
+channels such as environment variables; do not interpolate them into shell
+source.
+
+## The request is denied
+
+Typical signal: `status: denied` or `error-code: POLICY_DENIED`.
+
+Check these in order:
+
+1. Confirm the event is supported and an interactive `@dsh` command starts on
+   the first line of the comment or review. See [Usage](usage.md).
+2. Confirm every originating actor has write, maintain, or admin permission.
+   Permission lookup failures deny authority. For `workflow_run` writes, the
+   receiving actor, upstream run actor, and rerun/triggering actor must all pass.
+3. Confirm the target is in the same repository. Forks and
+   `pull_request_target` are always review-only.
+4. For a write, confirm `allow-write: "true"`, `run-tests: "true"`, and a
+   non-empty JSON `test-commands` list. `run-tests: "false"` denies the write;
+   it never waives validation.
+5. Confirm the bound issue, pull request, branch, origin, and full SHA have not
+   changed during the run, and that no protected path is being modified.
+6. Confirm `workspace.edit` survives the permission profile and exact deny
+   list. A workflow token with write scope cannot manufacture an Agent grant.
+
+A denied read-only request creates no progress comment. A write request also
+creates no lifecycle or status comment before final Controller validation
+succeeds (or a no-change result is confirmed). The absence of a bot comment is
+therefore expected for many denials and is not evidence that the Action did not
+run.
+
+If the failure is `ACTION_CONFIGURATION`, fix malformed or contradictory inputs
+before retrying. If it is `EVENT_ROUTING_FAILED`, fix the event/command pairing
+rather than broadening permissions.
+
+## A tool is missing or denied
+
+Inspect `trust`, `permission-profile`, `effective-tools`, `workspace-write`,
+`network-access`, and the permission audit in `result-json`.
+
+Common causes:
+
+- `custom` starts empty. List every required canonical ID in `allowed-tools`.
+- With `strict` or `standard`, `allowed-tools` adds requests after preset
+  expansion; it does not replace the preset. Use `custom` for an exact minimal
+  set.
+- `disallowed-tools` always wins over both a preset and `allowed-tools`.
+- Declaring a command, MCP server, Bundle, or plugin does not grant its tools.
+  The matching `command.*`, `mcp.*`, or `plugin.*` ID must also be allowed.
+- The event/actor trust profile can remove a requested tool. Forks receive no
+  repository tools. Trusted-read work denies edit, Bash, and subagent.
+- `native.bash` and `native.subagent` require eligible trusted-write Docker
+  policy. `native.bash` cannot share a worker with a bridge-networked extension.
+- `native.web-search` uses a separate Controller-mediated endpoint. It is not
+  arbitrary web fetch and does not grant general bridge egress.
+- Extension tools require `permission-profile: custom` (with `strict` retained
+  only for older v0.4 compatibility), Docker isolation, matching declared
+  permissions, and a consistent process-level network/workspace mode.
+
+Use canonical IDs exactly:
+
+- `workspace.read`, `workspace.search`, `workspace.edit`;
+- `native.bash`, `native.web-search`, `native.subagent`;
+- `command.<name>`;
+- `mcp.<server>.<tool>`; and
+- `plugin.<extension>.<tool>`.
+
+Unknown IDs, undefined command tools, references to undeclared extension tools,
+missing runtime registrations, and tools that remain visible outside the
+effective allowlist all fail closed. The model cannot approve a tool, edit its
+profile, or expand its own permissions.
+
+## Docker or isolation fails
+
+Typical codes include `DSH_ISOLATION_UNAVAILABLE`, `DSH_ENVIRONMENT`, and
+`DSH_SPAWN`.
+
+- Verify Docker is installed and the runner account can reach the daemon. A
+  read-only check such as `docker version` in an earlier workflow step can make
+  runner problems clear.
+- Confirm `container-image` is exactly one Docker/OCI image reference. It cannot
+  begin with an option or contain argument-breaking whitespace.
+- Writes and effective extensions require a full lowercase
+  `name@sha256:<64 hex>` digest. A tag is not sufficient for those paths.
+- Review the pinned image as executable worker code. A valid digest proves
+  identity, not trustworthiness or platform compatibility.
+- Untrusted work, trusted writes, and effective MCP/Bundle/Plugin tools cannot
+  use `isolation: none`.
+- `dsh-executable` is an absolute-path trusted host compatibility option. It has
+  no OS/container boundary and cannot load extensions; use it only for an
+  eligible trusted-read run on a dedicated trusted runner.
+- If an image cannot be pulled, inspect registry access, platform compatibility,
+  daemon storage, and the runner's network policy. Do not work around the
+  identity check with a mutable image when a digest is required.
+
+The Action workspace is intentionally `.git`-less and run-scoped. Tools should
+not expect repository Git metadata or checkout credentials. Keep
+`persist-credentials: false`; Controller writes do not depend on credentials
+left by checkout.
+
+## The worker cannot reach the API or web search
+
+Typical code: `DSH_PROXY`.
+
+- Verify `DEEPSEEK_API_KEY` is configured and accepted by the selected upstream.
+- Verify `base-url` and, when `native.web-search` is effective,
+  `web-search-base-url`. Both are trusted destinations that receive the real
+  DeepSeek key through the Controller proxy.
+- Check API availability, TLS, the runner's outbound policy, and proxy settings.
+- Do not put the real DeepSeek key or GitHub token into `prompt`, tool argv,
+  extension env/headers/configuration, or validation commands.
+- `native.web-search` supports the configured DeepSeek Anthropic Messages route;
+  it does not enable arbitrary `web_fetch` requests or general network access.
+
+When extensions declare `network: false`, the DSH worker still reaches the
+Controller proxy through an inspected Docker host gateway. That route is not a
+port allowlist. Runner firewall policy must protect other host services. When an
+approved extension requests network, the co-hosted worker uses bridge egress,
+which is not destination-restricted.
+
+## The Action times out
+
+Relevant codes include:
+
+| Code                 | Meaning                                                              | First response                                                                 |
+| -------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `DSH_TIMEOUT`        | A DSH process exceeded its deadline.                                 | Reduce repository/task scope or increase the Action deadline.                  |
+| `AGENT_TIMEOUT`      | The complete multi-turn Agent loop exhausted the remaining deadline. | Reduce task and validation work, or increase `timeout-minutes`.                |
+| `VALIDATION_TIMEOUT` | A Controller validation command timed out.                           | Reduce or split validation work; ensure the command does not wait for input.   |
+| `AGENT_TURN_LIMIT`   | The loop used `max-turns` before reaching a valid terminal result.   | Make the task narrower or raise `max-turns` within its 1–10 range.             |
+| `AGENT_NO_PROGRESS`  | The same workspace revision repeated the same validation failure.    | Fix the validation setup or give the Agent the specific tool/context it lacks. |
+
+`timeout-minutes` covers the overall setup/execution deadline. Runtime
+installation, extension installation, each Agent turn, and each validation
+phase have their own bounded budgets and also receive only the remaining total
+time. Increasing the overall value cannot make an individual extension call
+ignore its configured `timeoutMs`.
+
+Set the job timeout a few minutes above the Action timeout. Cleanup and
+cancellation-comment finalization have fixed, short best-effort grace periods;
+they may extend wall-clock time slightly beyond the Action deadline but cannot
+hang indefinitely.
+
+For an extension tool timeout, also check its per-tool `timeoutMs`, per-tool
+`maxCalls`, and owner-wide `maxCalls`. Same-process plugin cancellation is
+cooperative. The overall Controller deadline is the hard boundary that can stop
+an uncooperative worker process.
+
+## Cancellation or a sticky comment remains “In progress”
+
+On `SIGTERM` or `SIGINT`, the Controller aborts the active worker and immediately
+attempts a bounded terminal sticky-comment update while run-scoped cleanup
+continues. Terminal-state guards prevent queued progress work from replacing a
+known result with “In progress.” A later authoritative non-cancellation failure
+may correct a provisional cancellation state.
+
+This finalization is best effort. `SIGKILL`, runner/host loss, a process crash,
+or a GitHub API/network outage can prevent all cleanup code from running. A
+sticky comment can then remain stale. Use the Actions run conclusion as the
+source of truth; do not interpret the comment as proof that work is still
+running.
+
+The v1 sticky marker names an operation result kind, not a run or head SHA.
+Preserve a per-PR, per-Issue, or per-run `concurrency` group in custom workflows
+so a slow or hard-cancelled older run cannot overwrite a newer result. If stale
+comments are operationally unacceptable, set `progress-comment: "false"` to
+disable intermediate lifecycle updates; this does not disable normal final
+publication.
+
+## Validation fails and nothing is written
+
+Typical codes: `VALIDATION_FAILED` or `VALIDATION_TIMEOUT`. `status` is
+`validation_failed` for both Controller command failure and invalid DSH
+structured output, so use `error.code` to distinguish them.
+
+- Confirm `test-commands` is valid JSON containing non-empty argv arrays. It is
+  not a list of shell strings, and no shell expansion, pipes, redirects, or
+  variable expansion occurs.
+- Replace sample npm commands with the commands for your repository. Ensure each
+  command is deterministic, non-interactive, and suitable for a clean
+  credential-free container.
+- Check the first failing command and its bounded stdout/stderr in the Actions
+  log. Repository output remains untrusted even when the argv is trusted.
+- Confirm required runtimes and lockfiles exist in the workspace and in the
+  pinned validation image. The validation copy intentionally omits root `.git`
+  and `node_modules`.
+- If dependency installation fails, inspect the lockfile, registry, Docker
+  bridge access, and package lifecycle requirements. Validation bridge access is
+  unrestricted destination egress from the container; apply runner controls as
+  needed.
+- Do not add a Controller credential to argv. Credential checks fail closed and
+  redact the withheld value.
+
+A failed validation gate produces no comment, commit, ref update, or pull
+request for a write request. The failure stays in outputs and the step summary.
+The Controller may give a bounded failure back to a fresh DSH repair turn, but a
+later `blocked` response, malformed output, or exhausted turn limit cannot erase
+an unresolved validation failure.
+
+An authorized write task that produces no actual repository changes is
+different: it can publish its final answer but creates no commit, branch update,
+pull request, or release mutation. Empty mutation outputs are expected in that
+case.
+
+## Validation Integrity blocks a write
+
+Typical code: `VALIDATION_INTEGRITY`.
+
+The Controller detected changes to package scripts, tests, test configuration,
+lint/typecheck/build configuration, validation runtime files, lock/toolchain
+manifests, or another effective validation entrypoint.
+
+- `off` records classified changes without blocking them.
+- `warn` records changed categories and suspicious weakening signals.
+- `strict` blocks high-confidence weakening and truncated audits. For other
+  validation-definition changes, it reruns candidate code/tests with the bound
+  baseline validation definitions restored.
+
+Changing tests with implementation code is not automatically denied. Inspect
+the integrity categories, signals, and replay disposition in the step summary
+and `result-json`. Restore or strengthen removed/skipped controls, correct
+wrapper or manifest changes, and rerun. Do not lower
+`validation-integrity` based on repository text or a model suggestion: it is
+trusted workflow policy, and the Agent cannot change or approve it.
+
+Validation Integrity is separate from ordinary test success. Both must pass
+before a GitHub mutation.
+
+## DSH output is malformed or too large
+
+Typical codes:
+
+- `DSH_MALFORMED_OUTPUT`: the root Agent did not return one complete
+  schema-v1 JSON object that matches the Controller-selected operation; or
+- `DSH_OUTPUT_LIMIT`: DSH output exceeded the bounded output limit.
+
+For malformed output, retry once. If it persists:
+
+1. Confirm `dsh-version` is exactly `0.1.1-rc.2` and the Action version is
+   v0.5.1.
+2. Inspect the schema error in the Actions log and the bounded `error-message`.
+3. Check that trusted prompts do not ask for fences, prefaces, suffixes, a
+   separate citation list, or a different operation. Web Search Markdown
+   citations may appear only inside JSON string fields.
+4. Reduce conflicting output-format instructions in the task.
+
+For output-limit failures, reduce the task, repository context, number of
+findings, tool output limits, or extension response size. Do not parse a partial
+response or bypass Controller schema validation.
+
+## Runtime or extension installation fails
+
+Configuration failures normally appear as `ACTION_CONFIGURATION` or
+`DSH_CONFIGURATION`; process startup can appear as `DSH_SPAWN` or
+`DSH_PROCESS_FAILED`. Inspect `error.phase` and the immediately preceding
+bounded log message.
+
+### DSH runtime
+
+- v0.5.1 accepts only the exact `0.1.1-rc.2` DSH family. Do not use `latest`, a
+  range, a floating Git ref, or mixed DSH package versions.
+- The runtime installs from the committed lockfile in an ephemeral,
+  credential-free container and audits the installed DSH inventory. Registry,
+  lockfile, integrity, or version mismatches fail closed.
+- Runtime reuse requires the complete audited identity to match. Temporary DSH
+  home, npm cache, package state, counters, and receipts are scoped to one
+  Action run; do not depend on cross-run mutable state.
+- A host `dsh-executable` is not an extension-compatible shortcut and does not
+  provide Docker isolation.
+
+### MCP
+
+- `mcp-config` must be valid schema-v1 JSON with unique server/tool IDs, and
+  every referenced canonical ID must exist in the manifest.
+- `stdio` commands must be an audited bare executable or absolute container
+  path outside `/workspace`. Shells, interpreters, package managers, downloaders,
+  Git, relative paths, and dynamic runners such as `npx` are rejected.
+- `streamable-http` requires HTTP(S), no embedded URL credentials or fragment,
+  and explicit network permission on the server and every tool.
+- A selected server uses fail-closed startup. If an allowed tool does not
+  register, or an unknown/unselected tool remains visible, the run fails rather
+  than silently changing the model's tool surface.
+- Tools owned by one server must agree on workspace-write mode and with the
+  server's network setting. All co-hosted extension owners must have compatible
+  process-level modes.
+
+### Bundle and Plugin packages
+
+- Use `permission-profile: custom`, `isolation: docker`, an immutable
+  digest-pinned `container-image`, an exact canonical tool allowlist, and
+  `allow-plugin-install: "true"`.
+- Each package source must be an exact semver or a GitHub `git+https` URL pinned
+  to a lowercase 40-character commit. Ranges, `latest`, floating refs, and
+  replacement of Controller-owned DSH packages are rejected.
+- Review the package, Bundle patch, and complete transitive dependency graph.
+  Npm lifecycle scripts are disabled during acquisition, but package
+  installation still uses bridge networking and startup still executes trusted
+  code.
+- Installation fails if an existing top-level runtime package is removed or its
+  version changes, the installed identity/pin differs, or a Bundle patch escapes
+  its installed package.
+
+ToolRuntime restricts model-routed calls only. It does **not** sandbox an
+approved stdio executable, Bundle, or plugin during initialization, startup,
+background work, or direct process I/O. If that code is not trusted at the
+process level, do not enable it. See [Extension contracts](extension-contracts.md)
+for the exact compatibility and audit rules.
+
+## GitHub publication fails
+
+Typical codes: `PUBLICATION_FAILED` or `WRITE_FAILED`.
+
+- Check the workflow token scopes in [Configuration](configuration.md) and the
+  complete templates in [Setup](setup.md). Progress and final comments use the
+  same Issue or pull-request write scope.
+- Confirm the token belongs to the expected repository and has not been replaced
+  with an empty or revoked credential.
+- Confirm `bot-user-id` is the numeric ID of the account that owns existing
+  sticky comments. User-forged markers and markers from a different bot are
+  intentionally ignored.
+- For `WRITE_FAILED`, check whether the bound branch, issue, pull request, origin,
+  base/head SHA, default branch, or actor authorization changed during the run.
+  The Controller revalidates identity immediately before mutation.
+- A publication API outage can occur after Agent work completed. Inspect
+  `result-json`, but do not manually publish model text without applying the same
+  review and security judgment.
+
+The Agent itself cannot push or open a PR and does not receive a GitHub client.
+Messages indicating that Git credentials are unavailable inside the worker are
+consistent with the security design; authorized mutation must pass back through
+the Controller.
+
+## Outputs appear empty
+
+- Give the Action step an `id` and reference that exact ID in later steps.
+- Use an `always()` condition because a failed Action step still writes outputs
+  before reporting failure.
+- `branch-name`, `pull-request-url`, `commit-sha`, and `comment-id` are empty when
+  they do not apply. Read-only tasks, entity-free answers, denied/failing writes,
+  and successful no-change writes commonly leave some or all of them empty.
+- `review-summary` is the backward-compatible alias; prefer `summary` for new
+  workflows.
+- Parse `effective-tools`, `trusted-extensions`, `tool-receipts`, and
+  `result-json` as JSON. Do not treat their encoded text as shell source.
+- Receipt arrays may be truncated to the Action output budget. Check
+  `truncated` and `droppedCount`; truncation does not weaken or expand
+  authorization.
+
+If `result-json` itself is unexpectedly empty, inspect the earliest workflow
+failure. A runner/host kill before Action finalization can prevent any final
+output write, just as it can prevent sticky-comment cleanup.
+
+## Cleanup leaves a container behind
+
+Validation and command tools use random named containers with `--rm`. On launch
+failure or timeout the Controller also attempts `docker rm --force`, and it
+removes temporary workspaces in finalization.
+
+Cleanup is best effort. A hard runner termination or unavailable Docker daemon
+can leave a `dsh-action-validation-*` or `dsh-action-tool-*` container. A
+self-hosted runner operator can inspect and reap those exact run-scoped
+containers after confirming they no longer belong to an active job. A cleanup
+failure never grants write authority and should not replace the primary Action
+diagnostic.
+
+## Security-sensitive failures
+
+`DSH_CREDENTIAL_LEAK` means a withheld Controller credential appeared in a
+worker-bound input or worker output. Stop treating the run as routine:
+
+1. rotate any credential that might have been exposed;
+2. inspect the trusted workflow inputs and linked Actions log;
+3. remove the secret from `prompt`, validation/tool argv, extension
+   configuration, or repository-generated output; and
+4. rerun only after the source is understood.
+
+The safety check does not echo the credential. For other suspected boundary
+failures, follow the private reporting instructions in
+[`SECURITY.md`](../SECURITY.md); do not open a public issue containing live
+credentials.
+
+## See also
+
+- [Setup](setup.md)
+- [Usage](usage.md)
+- [Configuration](configuration.md)
+- [Extension contracts](extension-contracts.md)
+- [Security policy](../SECURITY.md)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,153 @@
+# Usage
+
+[中文](usage.zh-CN.md) · [README](../README.md) · [Setup](setup.md) · [Configuration](configuration.md)
+
+DeepSeek Harness can run from automatic repository events, first-line `@dsh` commands, or an explicit prompt in a maintainer-authored automation workflow.
+
+## How operations are selected
+
+| Entry point                                                                                  | Resolved operation |
+| -------------------------------------------------------------------------------------------- | ------------------ |
+| Pull request `opened`, `synchronize`, `ready_for_review`, or `reopened` with `command: auto` | `review`           |
+| Failed `workflow_run` with the diagnosis template                                            | `diagnose`         |
+| Failed `workflow_run` with the trusted auto-fix template                                     | `fix`              |
+| First-line `@dsh task ...`                                                                   | `task`             |
+| First-line `@dsh review`                                                                     | `review`           |
+| First-line `@dsh diagnose`                                                                   | `diagnose`         |
+| First-line `@dsh fix`                                                                        | `fix`              |
+| First-line `@dsh implement` on an Issue                                                      | `implement`        |
+| Dispatch or schedule with `command: auto` and a non-empty `prompt`                           | `task`             |
+
+For an interactive command, the command must begin on the first line of the triggering comment. Later lines may continue the instruction. The Controller authorizes every originating actor before treating that command body as trusted operator instruction; permission lookup failure denies the request.
+
+The workflow's `if: contains(..., '@dsh')` expression is only a coarse job filter. The Action still performs exact parsing, context checks, and authorization.
+
+## General tasks
+
+Use `task` for repository questions, code analysis, or coding work that does not fit a specialized command.
+
+```text
+@dsh task --read Explain why this pull request needs a two-phase commit
+@dsh task --write Add empty-input coverage to the parser and run validation
+```
+
+`--read` is the default when the access flag is omitted. A read task can inspect only the tools left by the effective trust and permission policy.
+
+`--write` requests a capability; it does not authorize it. The workflow must also set `allow-write: "true"`, keep `run-tests: "true"`, provide at least one validation argv array for an actual mutation, run in an eligible same-repository context that is not `pull_request_target`, pass every actor and identity check, and retain `workspace.edit` after policy intersection. A fork pull request can never be upgraded to write mode.
+
+Result delivery depends on the target:
+
+- A read task attached to an Issue or PR reuses one Controller-owned task comment.
+- A read automation without an Issue or PR returns through the step summary and outputs.
+- An Issue-backed or entity-free write task creates a Controller-owned `dsh/task-*` branch and pull request; it never pushes directly to the default branch.
+- A write task attached to a same-repository PR can affect only the bound and revalidated PR head branch.
+- If an authorized write task produces no repository change, it may publish its final answer but creates no commit, ref, PR, or release mutation.
+
+## Pull request review
+
+Automatic review is the simplest entry point. The Action reads the bound diff and repository context, publishes one summary, and adds inline comments only for selected high-confidence findings. Re-running the same operation updates the Controller-owned summary marker instead of creating another summary comment.
+
+To request another review manually, comment:
+
+```text
+@dsh review
+```
+
+Fork and `pull_request_target` review remain read-only. The workflow must check out only the trusted base SHA; the worker receives no repository tools in the untrusted profile and never executes fork code.
+
+## CI diagnosis
+
+Use [`examples/ci-diagnose.yml`](../examples/ci-diagnose.yml) to run after a failed CI workflow. The Controller selects checks and logs by repository and immutable head SHA, bounds and redacts them, and labels them as untrusted before DSH reads them.
+
+An authorized maintainer can also request:
+
+```text
+@dsh diagnose
+```
+
+Diagnosis is read-only. It publishes the cause and suggested next step; it does not grant a shell or modify the repository.
+
+## Fix a pull request
+
+On an eligible same-repository pull request, use:
+
+```text
+@dsh fix
+```
+
+The workflow must explicitly enable trusted write mode and fixed validation commands. DSH edits a disposable `.git`-less workspace; the Controller checks actual changes, protected paths, validation, and Validation Integrity before it creates a commit or updates the bound PR branch. No write-task lifecycle comment is published before final validation succeeds.
+
+See [`examples/commands.yml`](../examples/commands.yml) for interactive fixes and [`examples/ci-auto-fix.yml`](../examples/ci-auto-fix.yml) for a failed-CI repair workflow.
+
+## Implement an Issue
+
+On an Issue, comment:
+
+```text
+@dsh implement
+```
+
+After authorization, the Controller binds the Issue and default-branch head, runs the same edit and validation gates, creates a dedicated branch, and opens a pull request. Editing the bound Issue specification or moving the default-branch head during the operation causes the write to fail closed. Merging the resulting PR is a separate maintainer action.
+
+## Explicit automation
+
+Automation is a workflow pattern, not an `@dsh automation` command. On `workflow_dispatch`, `repository_dispatch`, or `schedule`, `command: auto` plus a non-empty `prompt` selects `task`. You can set `command: task` explicitly; then `prompt` is required.
+
+```yaml
+with:
+  command: auto
+  prompt: "Check the dependency boundary, add tests if needed, and explain the result"
+  task-access: read
+```
+
+`task-access` defaults to `read`. A write value still passes every normal write gate and, for an Issue-backed or entity-free task, produces a branch and PR rather than a direct default-branch push.
+
+`prompt` is trusted control-plane configuration. Populate it only from a maintainer-authored workflow or a dispatch input whose callers you trust. Do not promote Issue bodies, PR content, logs, repository files, or model output into `prompt`. Apply the same provenance rule to all capability-bearing inputs, especially permission profiles, tool lists, validation, container/runtime, network endpoints, and extension configuration.
+
+The full read/write dispatch template is [`examples/task-automation.yml`](../examples/task-automation.yml).
+
+## Multi-turn tools, validation, and repair
+
+Every outer iteration is a fresh DSH turn bound to the same task, workspace, and Controller policy:
+
+```text
+DSH turn
+  ├─ needs_tool → an allowed tool runs → bounded, redacted result → next turn
+  ├─ final → Controller validation fails → bounded output → repair turn
+  ├─ final → validation passes → Controller publishes or writes
+  └─ blocked → neutral only when no Controller validation failure is pending
+```
+
+`max-turns` defaults to 3 and counts tool requests and validation repair turns. The Action's `timeout-minutes` is the overall setup and execution deadline. Runtime setup, extension installation, each Agent turn, and validation also have independent caps. Repeating the same validation failure on the same workspace revision stops with a no-progress error.
+
+A repair turn cannot erase an unresolved validation or Validation Integrity failure by returning `blocked`, exhausting its turns, or emitting malformed structured output. The original Controller failure remains authoritative until a later finalization passes.
+
+## Progress and results
+
+For an authorized read operation with an Issue or PR target, the Controller updates one sticky comment during major lifecycle stages and reuses the same marker for the final result.
+
+| Operation           | Marker      |
+| ------------------- | ----------- |
+| `task`              | `task`      |
+| `review`            | `summary`   |
+| `diagnose`          | `diagnosis` |
+| `fix` / `implement` | `write`     |
+
+`progress-comment` defaults to `true`. Setting it to `false` disables intermediate lifecycle updates only; normal summaries, inline findings, diagnoses, and authorized final results remain enabled.
+
+Write requests deliberately publish no lifecycle/status comment until validation succeeds or actual-change inspection confirms a no-change task. On failure, inspect the step summary and outputs. The Action sets scalar outputs and the schema-v1 `result-json` on success, neutral, and failure paths.
+
+Cancellation finalization is bounded and best effort. `SIGTERM` or `SIGINT` can update an eligible sticky comment, but `SIGKILL`, runner/host loss, a process crash, or GitHub API failure can leave it at “In progress.” See [Troubleshooting](troubleshooting.md) and treat the Actions conclusion as authoritative.
+
+For the complete output schema and a safe `always()` consumption example, see [Configuration](configuration.md#outputs).
+
+## Workflow templates
+
+- [Fork-safe review](../examples/fork-review.yml)
+- [Interactive commands](../examples/commands.yml)
+- [CI diagnosis](../examples/ci-diagnose.yml)
+- [Trusted CI auto-fix](../examples/ci-auto-fix.yml)
+- [General task automation](../examples/task-automation.yml)
+- [Controlled extensions](../examples/controlled-extensions.yml)
+
+All templates keep checkout credentials disabled. Replace their release tag with the corresponding immutable release commit SHA before production use.

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -1,0 +1,153 @@
+# 使用指南
+
+[English](usage.md) · [项目首页](../README.zh-CN.md) · [安装指南](setup.zh-CN.md) · [配置参考](configuration.md)
+
+DeepSeek Harness 可以由仓库自动事件、评论第一行的 `@dsh` 命令，或维护者编写的自动化 workflow 中的显式 prompt 启动。
+
+## 如何选择操作
+
+| 入口                                                                                     | 实际操作    |
+| ---------------------------------------------------------------------------------------- | ----------- |
+| PR 的 `opened`、`synchronize`、`ready_for_review` 或 `reopened` 事件，且 `command: auto` | `review`    |
+| 使用诊断模板的失败 `workflow_run`                                                        | `diagnose`  |
+| 使用受信任自动修复模板的失败 `workflow_run`                                              | `fix`       |
+| 第一行 `@dsh task ...`                                                                   | `task`      |
+| 第一行 `@dsh review`                                                                     | `review`    |
+| 第一行 `@dsh diagnose`                                                                   | `diagnose`  |
+| 第一行 `@dsh fix`                                                                        | `fix`       |
+| Issue 第一行 `@dsh implement`                                                            | `implement` |
+| dispatch 或 schedule 中 `command: auto`，并提供非空 `prompt`                             | `task`      |
+
+交互命令必须从触发评论的第一行开始，后续行可以继续写说明。Controller 会先校验所有来源 actor，再把命令正文视为操作者的受信任指令；无法查询权限时会拒绝请求。
+
+workflow 中的 `if: contains(..., '@dsh')` 只是粗略的 job 过滤条件。Action 仍会执行精确解析、上下文检查和授权。
+
+## 通用 task
+
+仓库问答、代码分析或不适合专用命令的编码工作，都可以使用 `task`。
+
+```text
+@dsh task --read 解释这个 PR 为什么需要两阶段提交
+@dsh task --write 为解析器补上空输入测试并运行验证
+```
+
+省略访问标记时，默认使用 `--read`。只读 task 只能使用经过实际信任与权限策略筛选后仍然有效的工具。
+
+`--write` 只是请求能力，不是授权。workflow 还必须设置 `allow-write: "true"`、保持 `run-tests: "true"`、为实际变更提供至少一个验证 argv 数组、运行在符合条件的同仓库且非 `pull_request_target` 的上下文中、通过所有 actor 与 identity 检查，并让 `workspace.edit` 在策略求交后仍然有效。fork PR 永远不能升级为写模式。
+
+结果的交付方式取决于目标：
+
+- 附着在 Issue 或 PR 上的只读 task 会复用一条 Controller-owned task 评论。
+- 没有 Issue 或 PR 的只读自动化通过 step summary 和 outputs 返回结果。
+- 以 Issue 为目标或没有实体目标的写 task 会创建 Controller-owned `dsh/task-*` 分支和 PR，不会直接推送默认分支。
+- 附着在同仓库 PR 上的写 task 只能影响已经绑定并重新校验的 PR head 分支。
+- 获准的写 task 如果没有产生仓库变化，可以发布最终回答，但不会创建 commit、ref、PR 或 Release 变更。
+
+## PR 审查
+
+自动审查是最简单的入口。Action 会读取已经绑定的 diff 和仓库上下文，发布一条汇总，并且只为经过筛选的高置信度问题添加行内评论。重新运行同一操作时，会更新 Controller-owned summary marker，不会再创建一条汇总评论。
+
+如需手动重新审查，可以评论：
+
+```text
+@dsh review
+```
+
+fork 和 `pull_request_target` 审查始终是只读的。workflow 只能检出受信任的 base SHA；untrusted profile 中的 worker 没有仓库工具，也不会运行 fork 代码。
+
+## CI 诊断
+
+使用 [`examples/ci-diagnose.yml`](../examples/ci-diagnose.yml) 在 CI workflow 失败后运行。Controller 会按仓库和不可变 head SHA 选择检查与日志，经过限长和脱敏后，明确标为不可信数据再交给 DSH。
+
+通过授权的维护者也可以评论：
+
+```text
+@dsh diagnose
+```
+
+诊断是只读操作，只会发布原因和建议的下一步，不会授予 shell 或修改仓库。
+
+## 修复 PR
+
+在符合条件的同仓库 PR 上使用：
+
+```text
+@dsh fix
+```
+
+workflow 必须显式启用受信任写模式和固定验证命令。DSH 在一次性的无 `.git` workspace 中修改文件；Controller 会检查实际变更、受保护路径、验证和 Validation Integrity，然后才创建 commit 或更新已经绑定的 PR 分支。最终验证成功前，不会发布写任务的生命周期评论。
+
+交互修复模板见 [`examples/commands.yml`](../examples/commands.yml)，失败 CI 修复模板见 [`examples/ci-auto-fix.yml`](../examples/ci-auto-fix.yml)。
+
+## 实现 Issue
+
+在 Issue 中评论：
+
+```text
+@dsh implement
+```
+
+授权通过后，Controller 会绑定 Issue 和默认分支 head，执行同样的修改与验证关卡，再创建专用分支并打开 PR。操作期间如果绑定的 Issue 规格被修改，或默认分支 head 发生变化，写入会默认拒绝。是否合并生成的 PR 仍由维护者另行决定。
+
+## 显式自动化
+
+自动化是一种 workflow 用法，不存在 `@dsh automation` 命令。在 `workflow_dispatch`、`repository_dispatch` 或 `schedule` 中，`command: auto` 加非空 `prompt` 会选择 `task`。也可以显式设置 `command: task`，此时 `prompt` 必填。
+
+```yaml
+with:
+  command: auto
+  prompt: "检查依赖边界，必要时补测试并解释结果"
+  task-access: read
+```
+
+`task-access` 默认是 `read`。设置为 write 后仍需通过全部写入关卡；对于 Issue-backed 或没有实体目标的 task，结果是分支和 PR，而不是直接推送默认分支。
+
+`prompt` 属于受信任的控制面配置。它只能来自维护者编写的 workflow，或调用者身份受信任的 dispatch 输入。不要把 Issue 正文、PR 内容、日志、仓库文件或模型输出提升为 `prompt`。所有带权限含义的输入都要遵守同一来源规则，尤其是权限档位、工具列表、验证、容器与运行时、网络 endpoint 和扩展配置。
+
+完整的读写 dispatch 模板见 [`examples/task-automation.yml`](../examples/task-automation.yml)。
+
+## 多轮工具、验证与修复
+
+每次外层迭代都会启动一个新的 DSH turn，但任务、workspace 和 Controller 策略保持绑定：
+
+```text
+DSH turn
+  ├─ needs_tool → 运行获准工具 → 限长、脱敏结果 → 下一轮
+  ├─ final → Controller 验证失败 → 限长输出 → 修复轮
+  ├─ final → 验证通过 → Controller 发布或写入
+  └─ blocked → 只有不存在 Controller 验证失败时才能返回 neutral
+```
+
+`max-turns` 默认是 3，同时计算工具请求和验证修复轮。Action 的 `timeout-minutes` 是 setup 与执行的总 deadline；runtime setup、扩展安装、每个 Agent turn 和验证还有独立上限。在相同 workspace revision 上重复出现同一个验证失败时，会以 no-progress 错误停止。
+
+修复轮不能通过返回 `blocked`、耗尽轮数或输出畸形结构化结果来抹去尚未解决的验证或 Validation Integrity 失败。只有后续 finalization 真正通过后，原始 Controller 失败才会解除。
+
+## 进度与结果
+
+获准的只读操作如果有 Issue 或 PR 目标，Controller 会在主要阶段更新一条 sticky comment，并让最终结果复用同一个 marker。
+
+| 操作                | Marker      |
+| ------------------- | ----------- |
+| `task`              | `task`      |
+| `review`            | `summary`   |
+| `diagnose`          | `diagnosis` |
+| `fix` / `implement` | `write`     |
+
+`progress-comment` 默认为 `true`。设为 `false` 只会关闭中间生命周期更新；正常汇总、行内问题、诊断和获准的最终结果仍会发布。
+
+写请求在验证成功或实际变更检查确认任务没有变化前，不会发布生命周期或状态评论。失败时请查看 step summary 和 outputs。Action 在 success、neutral 和 failure 路径都会设置标量 outputs 和 schema-v1 `result-json`。
+
+取消收尾有明确时间上限，但只能尽力完成。`SIGTERM` 或 `SIGINT` 可以更新符合条件的 sticky comment；`SIGKILL`、runner/host 丢失、进程崩溃或 GitHub API 失败仍可能让评论停在 “In progress”。应以 Actions conclusion 为准，详见[故障排查](troubleshooting.md)。
+
+完整 output schema 和安全的 `always()` 读取示例见[配置参考](configuration.md#outputs)。
+
+## Workflow 模板
+
+- [安全的 fork 审查](../examples/fork-review.yml)
+- [交互命令](../examples/commands.yml)
+- [CI 诊断](../examples/ci-diagnose.yml)
+- [受信任 CI 自动修复](../examples/ci-auto-fix.yml)
+- [通用 task 自动化](../examples/task-automation.yml)
+- [受控扩展](../examples/controlled-extensions.yml)
+
+所有模板都禁用了 checkout 凭据。生产环境请把模板中的发布 Tag 替换为对应版本的完整、不可变 release commit SHA。

--- a/examples/ci-auto-fix.yml
+++ b/examples/ci-auto-fix.yml
@@ -37,5 +37,6 @@ jobs:
           allow-write: "true"
           run-tests: "true"
           validation-integrity: strict
+          # Replace these validation commands with the commands for your repository.
           test-commands: '[["npm","ci","--ignore-scripts"],["npm","test"],["npm","run","typecheck"]]'
           container-image: docker.io/library/node:24.18.0-bookworm@sha256:5711a0d445a1af54af9589066c646df387d1831a608226f4cd694fc59e745059

--- a/examples/commands.yml
+++ b/examples/commands.yml
@@ -37,5 +37,6 @@ jobs:
           allow-write: "true"
           run-tests: "true"
           validation-integrity: strict
+          # Replace these validation commands with the commands for your repository.
           test-commands: '[["npm","ci","--ignore-scripts"],["npm","test"],["npm","run","typecheck"]]'
           container-image: docker.io/library/node:24.18.0-bookworm@sha256:5711a0d445a1af54af9589066c646df387d1831a608226f4cd694fc59e745059

--- a/examples/task-automation.yml
+++ b/examples/task-automation.yml
@@ -55,6 +55,7 @@ jobs:
           max-turns: "5"
           run-tests: "true"
           validation-integrity: strict
+          # Replace these validation commands with the commands for your repository.
           test-commands: >-
             [
               ["npm","ci","--ignore-scripts"],


### PR DESCRIPTION
## Summary

- turn both READMEs into concise English/Chinese product homepages
- add layered setup, usage, configuration, troubleshooting, extension, and maintainer-release documentation
- add a concise contributor guide and repository-specific validation reminders to write-capable examples
- keep the existing security model and limitations explicit, including Controller-only GitHub mutation and trusted extension startup code

## Scope

Documentation and YAML comments only. No `src/`, `dist/`, runtime assets, Action metadata, package/lock, workflow behavior, input/output semantics, or permission policy changes.

## Verification

- Markdown relative links: 149 targets across 15 files
- English/Chinese README, setup, and usage structure parity
- configuration coverage: 27/27 inputs and 21/21 outputs
- Prettier, ESLint, TypeScript, 523 tests (1 skipped), coverage, release contract, and DSH configuration audit passed locally
- clean PR CI on `f31288458b393e957ede8a9d50efc2cdc188495b`: `npm ci`, full `npm run check`, and Linux Docker/DSH runtime smoke passed
- `dist/` and all product/runtime boundary files match the v0.5.1 baseline

## Check status note

The automatic DSH review was hard-cancelled by its outer 30-minute GitHub job limit before it produced a review result. It reported no documentation finding, and its sticky comment remains at `In progress` because the runner was forcibly terminated. The clean CI run above passed on the same PR head SHA.