### PR TITLE
test: harden v0.6.0 release qualification E2E

### DIFF
--- a/.github/e2e/assert-candidate-binding.sh
+++ b/.github/e2e/assert-candidate-binding.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${GH_TOKEN:?}" "${REPOSITORY:?}" "${DEFAULT_BRANCH:?}" "${CANDIDATE_MODE:?}" "${CANDIDATE_SHA:?}"
+sha_pattern='^[a-f0-9]{40}$'
+[[ "$CANDIDATE_SHA" =~ $sha_pattern ]]
+
+case "$CANDIDATE_MODE" in
+  pull-request)
+    : "${CANDIDATE_PR:?}"
+    [[ "$CANDIDATE_PR" =~ ^[1-9][0-9]*$ ]]
+    pr_json="$(gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR")"
+    jq -e --arg sha "$CANDIDATE_SHA" --arg repo "${REPOSITORY,,}" --arg base "$DEFAULT_BRANCH" '
+      .state == "open" and .draft == false and .head.sha == $sha and
+      (.head.repo.full_name | ascii_downcase) == $repo and
+      (.base.repo.full_name | ascii_downcase) == $repo and .base.ref == $base
+    ' <<<"$pr_json" >/dev/null
+    ;;
+  main)
+    [[ -z "${CANDIDATE_PR:-}" ]]
+    live_sha="$(gh api "repos/$REPOSITORY/git/ref/heads/$DEFAULT_BRANCH" --jq .object.sha)"
+    [[ "$live_sha" =~ $sha_pattern && "$live_sha" == "$CANDIDATE_SHA" ]]
+    ;;
+  *)
+    echo "Unsupported candidate mode: $CANDIDATE_MODE" >&2
+    exit 1
+    ;;
+esac

--- a/.github/e2e/github-integration-llm.mjs
+++ b/.github/e2e/github-integration-llm.mjs
@@ -3,8 +3,14 @@ import { createServer } from "node:http";
 
 const auditPath = process.env.DSH_E2E_GITHUB_AUDIT;
 const expectedKey = process.env.DSH_E2E_FIXTURE_KEY;
+const issueLabel = process.env.DSH_E2E_ISSUE_LABEL;
+const issueAssignee = process.env.DSH_E2E_ISSUE_ASSIGNEE;
+const pullTitle = process.env.DSH_E2E_PULL_TITLE;
 if (!auditPath) throw new Error("DSH_E2E_GITHUB_AUDIT is required");
 if (!expectedKey) throw new Error("DSH_E2E_FIXTURE_KEY is required");
+if (!issueLabel) throw new Error("DSH_E2E_ISSUE_LABEL is required");
+if (!issueAssignee) throw new Error("DSH_E2E_ISSUE_ASSIGNEE is required");
+if (!pullTitle) throw new Error("DSH_E2E_PULL_TITLE is required");
 
 const calls = new Map();
 
@@ -44,18 +50,36 @@ function finalTask(route) {
 }
 
 function fixtureOutput(route, index) {
-  if (route === "github" && index === 1) {
+  if (route === "github" && index <= 4) {
+    const requests = [
+      {
+        id: "github.issue.labels.set",
+        input: { labels: [issueLabel] },
+        reason: "Exercise the Controller-owned exact label replacement path.",
+      },
+      {
+        id: "github.issue.assignees.set",
+        input: { assignees: [issueAssignee] },
+        reason: "Exercise the Controller-owned exact assignee replacement path.",
+      },
+      {
+        id: "github.comment.create",
+        input: { body: "DSH E2E typed GitHub tool completed for @maintainers." },
+        reason: "Exercise the Controller-owned reconciled comment path.",
+      },
+      {
+        id: "github.issue.state.update",
+        input: { state: "closed", stateReason: "completed" },
+        reason: "Exercise the Controller-owned bounded Issue state path last.",
+      },
+    ];
     return {
       protocolVersion: 1,
       operation: "task",
       state: "needs_tool",
-      summary: "Schedule the exact typed GitHub comment operation.",
+      summary: `Schedule typed GitHub Issue operation ${String(index)}.`,
       findings: [],
-      toolRequest: {
-        id: "github.comment.create",
-        input: { body: "DSH E2E typed GitHub tool completed for @maintainers." },
-        reason: "Exercise the Controller-owned typed mutation path.",
-      },
+      toolRequest: requests[index - 1],
     };
   }
   if (route === "label" || route === "assignee" || route === "github") {
@@ -85,6 +109,29 @@ function fixtureOutput(route, index) {
       diagnosis: "The typed Controller check/status response was available as bounded data.",
     };
   }
+  if (route === "metadata" && index === 1) {
+    return {
+      protocolVersion: 1,
+      operation: "task",
+      state: "needs_tool",
+      summary: "Schedule the exact typed pull request metadata operation.",
+      findings: [],
+      toolRequest: {
+        id: "github.pull.metadata.update",
+        input: { title: pullTitle },
+        reason: "Exercise the Controller-owned bounded pull request metadata path.",
+      },
+    };
+  }
+  if (route === "metadata") {
+    return {
+      protocolVersion: 1,
+      operation: "task",
+      state: "final",
+      summary: "Deterministic pull request metadata update completed.",
+      findings: [],
+    };
+  }
   throw new Error(`unexpected fixture route: ${route}`);
 }
 
@@ -109,7 +156,7 @@ const server = createServer((request, response) => {
     response.writeHead(200, { "content-type": "text/plain" }).end("ok\n");
     return;
   }
-  const match = /^\/(label|assignee|github|checks)\/(?:v1\/)?chat\/completions$/u.exec(
+  const match = /^\/(label|assignee|github|metadata|checks)\/(?:v1\/)?chat\/completions$/u.exec(
     request.url ?? "",
   );
   if (request.method !== "POST" || match === null) {

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,19 +3,27 @@ name: Core E2E
 on:
   workflow_dispatch:
     inputs:
+      candidate_mode:
+        description: "Qualification target: an open pull request head or the live main release commit"
+        required: true
+        default: pull-request
+        type: choice
+        options:
+          - pull-request
+          - main
       candidate_sha:
         description: Full lowercase SHA of the candidate action commit
         required: true
         type: string
       pull_request:
-        description: Open same-repository PR whose head is candidate_sha
-        required: true
+        description: Open same-repository PR whose head is candidate_sha; omit for main mode
+        required: false
         type: number
 
 permissions: {}
 
 concurrency:
-  group: dsh-core-e2e-${{ github.repository }}-${{ inputs.pull_request }}
+  group: dsh-core-e2e-${{ github.repository }}
   cancel-in-progress: false
 
 jobs:
@@ -28,6 +36,7 @@ jobs:
       pull-requests: read
     outputs:
       run_e2e: ${{ steps.bind.outputs.run_e2e }}
+      candidate_mode: ${{ steps.bind.outputs.candidate_mode }}
       candidate_sha: ${{ steps.bind.outputs.candidate_sha }}
       candidate_branch: ${{ steps.bind.outputs.candidate_branch }}
       pull_request: ${{ steps.bind.outputs.pull_request }}
@@ -44,9 +53,10 @@ jobs:
           WORKFLOW_SHA: ${{ github.workflow_sha }}
           DISPATCH_SHA: ${{ github.sha }}
           ACTOR: ${{ github.actor }}
+          CANDIDATE_MODE: ${{ inputs.candidate_mode }}
           CANDIDATE_SHA: ${{ inputs.candidate_sha }}
           CANDIDATE_PR: ${{ inputs.pull_request }}
-          APPROVED_PR_SHA: ${{ vars.DSH_E2E_CANDIDATE_SHA }}
+          APPROVED_CANDIDATE_SHA: ${{ vars.DSH_E2E_CANDIDATE_SHA }}
         run: |
           set -euo pipefail
           sha_pattern='^[a-f0-9]{40}$'
@@ -72,36 +82,60 @@ jobs:
             echo "candidate_sha must be a full lowercase commit SHA" >&2
             exit 1
           }
-          [[ "$CANDIDATE_PR" =~ ^[1-9][0-9]*$ ]] || {
-            echo "pull_request must be a positive integer" >&2
-            exit 1
-          }
-          [[ "$APPROVED_PR_SHA" =~ $sha_pattern && "$APPROVED_PR_SHA" == "$CANDIDATE_SHA" ]] || {
+          [[ "$APPROVED_CANDIDATE_SHA" =~ $sha_pattern && "$APPROVED_CANDIDATE_SHA" == "$CANDIDATE_SHA" ]] || {
             echo "DSH_E2E_CANDIDATE_SHA must exactly match candidate_sha" >&2
             exit 1
           }
-
-          pr_json="$(gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR")"
-          jq -e \
-            --arg sha "$CANDIDATE_SHA" \
-            --arg repo "${REPOSITORY,,}" \
-            --arg base "$DEFAULT_BRANCH" \
-            '(.state == "open") and (.draft == false) and
-             (.head.sha == $sha) and (.head.repo.full_name | ascii_downcase) == $repo and
-             (.base.repo.full_name | ascii_downcase) == $repo and (.base.ref == $base)' \
-            <<<"$pr_json" >/dev/null
 
           permission="$(gh api "repos/$REPOSITORY/collaborators/$ACTOR/permission" --jq .permission 2>/dev/null || true)"
           [[ "$permission" == "write" || "$permission" == "maintain" || "$permission" == "admin" ]] || {
             echo "The triggering actor must have repository write permission" >&2
             exit 1
           }
+
+          case "$CANDIDATE_MODE" in
+            pull-request)
+              [[ "$CANDIDATE_PR" =~ ^[1-9][0-9]*$ ]] || {
+                echo "pull_request must be a positive integer in pull-request mode" >&2
+                exit 1
+              }
+              pr_json="$(gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR")"
+              jq -e \
+                --arg sha "$CANDIDATE_SHA" \
+                --arg repo "${REPOSITORY,,}" \
+                --arg base "$DEFAULT_BRANCH" \
+                '(.state == "open") and (.draft == false) and
+                 (.head.sha == $sha) and (.head.repo.full_name | ascii_downcase) == $repo and
+                 (.base.repo.full_name | ascii_downcase) == $repo and (.base.ref == $base)' \
+                <<<"$pr_json" >/dev/null
+              candidate_branch="$(jq -r .head.ref <<<"$pr_json")"
+              summary="Bound PR #$CANDIDATE_PR to candidate $CANDIDATE_SHA"
+              ;;
+            main)
+              [[ -z "$CANDIDATE_PR" || "$CANDIDATE_PR" == "0" ]] || {
+                echo "pull_request must be omitted in main mode" >&2
+                exit 1
+              }
+              [[ "$CANDIDATE_SHA" == "$DISPATCH_SHA" && "$CANDIDATE_SHA" == "$default_sha" ]] || {
+                echo "main mode requires candidate_sha to equal the live immutable default-branch commit" >&2
+                exit 1
+              }
+              CANDIDATE_PR=""
+              candidate_branch="$DEFAULT_BRANCH"
+              summary="Bound post-merge qualification to live $DEFAULT_BRANCH commit $CANDIDATE_SHA"
+              ;;
+            *)
+              echo "candidate_mode must be pull-request or main" >&2
+              exit 1
+              ;;
+          esac
           echo "run_e2e=true" >> "$GITHUB_OUTPUT"
+          echo "candidate_mode=$CANDIDATE_MODE" >> "$GITHUB_OUTPUT"
           echo "candidate_sha=$CANDIDATE_SHA" >> "$GITHUB_OUTPUT"
-          echo "candidate_branch=$(jq -r .head.ref <<<"$pr_json")" >> "$GITHUB_OUTPUT"
+          echo "candidate_branch=$candidate_branch" >> "$GITHUB_OUTPUT"
           echo "pull_request=$CANDIDATE_PR" >> "$GITHUB_OUTPUT"
           echo "harness_sha=$DISPATCH_SHA" >> "$GITHUB_OUTPUT"
-          echo "Bound PR #$CANDIDATE_PR to candidate $CANDIDATE_SHA from the trusted default-branch workflow" >> "$GITHUB_STEP_SUMMARY"
+          echo "$summary from the trusted default-branch workflow" >> "$GITHUB_STEP_SUMMARY"
 
   read_only:
     name: Read-only golden paths
@@ -285,22 +319,18 @@ jobs:
             (.loop.dshToolReceipts | map(select(.id == "native.web-search" and .completed == true and .ok == true)) | length == 1)
           ' <<<"$RESULT_JSON" >/dev/null
 
-      - name: Revalidate candidate PR identity
+      - name: Revalidate candidate identity
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          CANDIDATE_MODE: ${{ needs.gate.outputs.candidate_mode }}
           CANDIDATE_SHA: ${{ needs.gate.outputs.candidate_sha }}
           CANDIDATE_PR: ${{ needs.gate.outputs.pull_request }}
         run: |
           set -euo pipefail
-          pr_json="$(gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR")"
-          jq -e --arg sha "$CANDIDATE_SHA" --arg repo "${REPOSITORY,,}" --arg base "$DEFAULT_BRANCH" '
-            .state == "open" and .draft == false and .head.sha == $sha and
-            (.head.repo.full_name | ascii_downcase) == $repo and
-            (.base.repo.full_name | ascii_downcase) == $repo and .base.ref == $base
-          ' <<<"$pr_json" >/dev/null
+          bash .github/e2e/assert-candidate-binding.sh
 
   write:
     name: Write guards and golden paths
@@ -340,6 +370,7 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           HARNESS_SHA: ${{ needs.gate.outputs.harness_sha }}
+          CANDIDATE_MODE: ${{ needs.gate.outputs.candidate_mode }}
           CANDIDATE_SHA: ${{ needs.gate.outputs.candidate_sha }}
           CANDIDATE_PR: ${{ needs.gate.outputs.pull_request }}
           DEEPSEEK_SECRET_PRESENT: ${{ secrets.DEEPSEEK_API_KEY != '' }}
@@ -355,19 +386,29 @@ jobs:
           set -euo pipefail
           export LC_ALL=C
           prefix="$1"
-          : "${REPOSITORY:?}" "${DEFAULT_BRANCH:?}" "${CANDIDATE_PR:?}"
+          : "${REPOSITORY:?}" "${DEFAULT_BRANCH:?}" "${CANDIDATE_MODE:?}"
           gh api "repos/$REPOSITORY/git/ref/heads/$DEFAULT_BRANCH" --jq .object.sha > "$prefix.main"
-          gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR" | jq -cS '{
-            number,state,draft,
-            head:{repo:.head.repo.full_name,ref:.head.ref,sha:.head.sha},
-            base:{repo:.base.repo.full_name,ref:.base.ref,sha:.base.sha},
-            body:(.body // "")
-          }' > "$prefix.candidate"
+          if [[ "$CANDIDATE_MODE" == "pull-request" ]]; then
+            : "${CANDIDATE_PR:?}"
+            gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR" | jq -cS '{
+              number,state,draft,
+              head:{repo:.head.repo.full_name,ref:.head.ref,sha:.head.sha},
+              base:{repo:.base.repo.full_name,ref:.base.ref,sha:.base.sha},
+              body:(.body // "")
+            }' > "$prefix.candidate"
+          else
+            jq -cn --arg mode "$CANDIDATE_MODE" --arg sha "$CANDIDATE_SHA" \
+              '{mode:$mode,sha:$sha}' > "$prefix.candidate"
+          fi
           gh api --paginate "repos/$REPOSITORY/pulls?state=all&per_page=100" \
             --jq '.[].number' | sort -n > "$prefix.prs"
-          gh api --paginate "repos/$REPOSITORY/issues/$CANDIDATE_PR/comments?per_page=100" \
-            --jq '.[] | {id,userId:.user.id,updatedAt:.updated_at,body}' \
-            | jq -cS . | sort > "$prefix.comments"
+          if [[ "$CANDIDATE_MODE" == "pull-request" ]]; then
+            gh api --paginate "repos/$REPOSITORY/issues/$CANDIDATE_PR/comments?per_page=100" \
+              --jq '.[] | {id,userId:.user.id,updatedAt:.updated_at,body}' \
+              | jq -cS . | sort > "$prefix.comments"
+          else
+            : > "$prefix.comments"
+          fi
           gh api --paginate "repos/$REPOSITORY/git/matching-refs/heads/dsh/task-?per_page=100" \
             --jq '.[] | [.ref,.object.type,.object.sha] | @tsv' | sort > "$prefix.task-refs"
           gh api --paginate "repos/$REPOSITORY/pulls?state=all&per_page=100" --jq '
@@ -389,12 +430,7 @@ jobs:
 
           prefix="$RUNNER_TEMP/dsh-e2e-baseline"
           "$RUNNER_TEMP/dsh-e2e-snapshot.sh" "$prefix"
-          pr_json="$(gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR")"
-          jq -e --arg sha "$CANDIDATE_SHA" --arg repo "${REPOSITORY,,}" --arg base "$DEFAULT_BRANCH" '
-            .state == "open" and .draft == false and .head.sha == $sha and
-            (.head.repo.full_name | ascii_downcase) == $repo and
-            (.base.repo.full_name | ascii_downcase) == $repo and .base.ref == $base
-          ' <<<"$pr_json" >/dev/null
+          bash .github/e2e/assert-candidate-binding.sh
           echo "main_sha=$(cat "$prefix.main")" >> "$GITHUB_OUTPUT"
 
       - name: Validation Integrity blocks weakened entrypoint
@@ -452,6 +488,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          CANDIDATE_MODE: ${{ needs.gate.outputs.candidate_mode }}
+          CANDIDATE_SHA: ${{ needs.gate.outputs.candidate_sha }}
           CANDIDATE_PR: ${{ needs.gate.outputs.pull_request }}
         run: |
           set -euo pipefail
@@ -492,6 +530,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          CANDIDATE_MODE: ${{ needs.gate.outputs.candidate_mode }}
+          CANDIDATE_SHA: ${{ needs.gate.outputs.candidate_sha }}
           CANDIDATE_PR: ${{ needs.gate.outputs.pull_request }}
           RESULT_JSON: ${{ steps.validation.outputs['result-json'] }}
           EXPECTED_FAILURE: ${{ steps.validation.outcome == 'failure' }}
@@ -542,6 +582,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          CANDIDATE_MODE: ${{ needs.gate.outputs.candidate_mode }}
+          CANDIDATE_SHA: ${{ needs.gate.outputs.candidate_sha }}
           CANDIDATE_PR: ${{ needs.gate.outputs.pull_request }}
           RESULT_JSON: ${{ steps.no_change.outputs['result-json'] }}
         run: |
@@ -591,6 +633,7 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           BASE_BRANCH: ${{ needs.gate.outputs.candidate_branch }}
+          CANDIDATE_MODE: ${{ needs.gate.outputs.candidate_mode }}
           CANDIDATE_SHA: ${{ needs.gate.outputs.candidate_sha }}
           CANDIDATE_PR: ${{ needs.gate.outputs.pull_request }}
           RESULT_JSON: ${{ steps.trusted.outputs['result-json'] }}
@@ -631,12 +674,7 @@ jobs:
             | jq -e --arg path "$FILE_PATH" '.files | length == 1 and .[0].filename == $path and .[0].status == "added"' >/dev/null
           content="$(gh api "repos/$REPOSITORY/contents/$FILE_PATH?ref=$head_sha" --jq .content | tr -d '\n' | base64 --decode)"
           [[ "$content" == "trusted-write" ]]
-          candidate_json="$(gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR")"
-          jq -e --arg sha "$CANDIDATE_SHA" --arg repo "${REPOSITORY,,}" --arg base "$DEFAULT_BRANCH" '
-            .state == "open" and .draft == false and .head.sha == $sha and
-            (.head.repo.full_name | ascii_downcase) == $repo and
-            (.base.repo.full_name | ascii_downcase) == $repo and .base.ref == $base
-          ' <<<"$candidate_json" >/dev/null
+          bash .github/e2e/assert-candidate-binding.sh
 
       - name: Close only the verified E2E PR and delete its branch
         if: ${{ always() && steps.trusted.outcome != 'skipped' }}
@@ -700,23 +738,19 @@ jobs:
             exit 1
           fi
 
-      - name: Revalidate candidate PR identity and credential-free checkout
+      - name: Revalidate candidate identity and credential-free checkout
         if: always()
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          CANDIDATE_MODE: ${{ needs.gate.outputs.candidate_mode }}
           CANDIDATE_SHA: ${{ needs.gate.outputs.candidate_sha }}
           CANDIDATE_PR: ${{ needs.gate.outputs.pull_request }}
         run: |
           set -euo pipefail
-          pr_json="$(gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR")"
-          jq -e --arg sha "$CANDIDATE_SHA" --arg repo "${REPOSITORY,,}" --arg base "$DEFAULT_BRANCH" '
-            .state == "open" and .draft == false and .head.sha == $sha and
-            (.head.repo.full_name | ascii_downcase) == $repo and
-            (.base.repo.full_name | ascii_downcase) == $repo and .base.ref == $base
-          ' <<<"$pr_json" >/dev/null
+          bash .github/e2e/assert-candidate-binding.sh
           ! git -C . config --local --get-regexp '^(http\..*\.extraheader|credential\.)' >/dev/null 2>&1
           ! git -C candidate-action config --local --get-regexp '^(http\..*\.extraheader|credential\.)' >/dev/null 2>&1
 
@@ -758,6 +792,7 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           HARNESS_SHA: ${{ needs.gate.outputs.harness_sha }}
+          CANDIDATE_MODE: ${{ needs.gate.outputs.candidate_mode }}
           CANDIDATE_SHA: ${{ needs.gate.outputs.candidate_sha }}
           CANDIDATE_PR: ${{ needs.gate.outputs.pull_request }}
           DEEPSEEK_SECRET_PRESENT: ${{ secrets.DEEPSEEK_API_KEY != '' }}
@@ -771,24 +806,26 @@ jobs:
           ! git -C candidate-action config --local --get-regexp '^(http\..*\.extraheader|credential\.)' >/dev/null 2>&1
           node --check .github/e2e/hanging-http-server.mjs
 
-          pr_json="$(gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR")"
-          jq -e --arg sha "$CANDIDATE_SHA" --arg repo "${REPOSITORY,,}" --arg base "$DEFAULT_BRANCH" '
-            .state == "open" and .draft == false and .head.sha == $sha and
-            (.head.repo.full_name | ascii_downcase) == $repo and
-            (.base.repo.full_name | ascii_downcase) == $repo and .base.ref == $base
-          ' <<<"$pr_json" >/dev/null
+          bash .github/e2e/assert-candidate-binding.sh
 
           prefix="$RUNNER_TEMP/dsh-e2e-cancel-baseline"
           gh api "repos/$REPOSITORY/git/ref/heads/$DEFAULT_BRANCH" --jq .object.sha > "$prefix.main"
-          jq -cS '{
-            number,state,draft,
-            head:{repo:.head.repo.full_name,ref:.head.ref,sha:.head.sha},
-            base:{repo:.base.repo.full_name,ref:.base.ref,sha:.base.sha},
-            body:(.body // "")
-          }' <<<"$pr_json" > "$prefix.candidate"
-          gh api --paginate "repos/$REPOSITORY/issues/$CANDIDATE_PR/comments?per_page=100" \
-            --jq '.[] | {id,userId:.user.id,updatedAt:.updated_at,body}' \
-            | jq -cS . | sort > "$prefix.comments"
+          if [[ "$CANDIDATE_MODE" == "pull-request" ]]; then
+            pr_json="$(gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR")"
+            jq -cS '{
+              number,state,draft,
+              head:{repo:.head.repo.full_name,ref:.head.ref,sha:.head.sha},
+              base:{repo:.base.repo.full_name,ref:.base.ref,sha:.base.sha},
+              body:(.body // "")
+            }' <<<"$pr_json" > "$prefix.candidate"
+            gh api --paginate "repos/$REPOSITORY/issues/$CANDIDATE_PR/comments?per_page=100" \
+              --jq '.[] | {id,userId:.user.id,updatedAt:.updated_at,body}' \
+              | jq -cS . | sort > "$prefix.comments"
+          else
+            jq -cn --arg mode "$CANDIDATE_MODE" --arg sha "$CANDIDATE_SHA" \
+              '{mode:$mode,sha:$sha}' > "$prefix.candidate"
+            : > "$prefix.comments"
+          fi
           gh api --paginate "repos/$REPOSITORY/git/matching-refs/heads/dsh/task-?per_page=100" \
             --jq '.[] | [.ref,.object.type,.object.sha] | @tsv' | sort > "$prefix.task-refs"
           gh api --paginate "repos/$REPOSITORY/pulls?state=all&per_page=100" --jq '
@@ -1035,6 +1072,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          CANDIDATE_MODE: ${{ needs.gate.outputs.candidate_mode }}
           CANDIDATE_SHA: ${{ needs.gate.outputs.candidate_sha }}
           CANDIDATE_PR: ${{ needs.gate.outputs.pull_request }}
         run: |
@@ -1043,22 +1081,24 @@ jobs:
           prefix="$RUNNER_TEMP/dsh-e2e-cancel-baseline"
           current="$RUNNER_TEMP/dsh-e2e-cancel-current"
 
-          pr_json="$(gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR")"
-          jq -e --arg sha "$CANDIDATE_SHA" --arg repo "${REPOSITORY,,}" --arg base "$DEFAULT_BRANCH" '
-            .state == "open" and .draft == false and .head.sha == $sha and
-            (.head.repo.full_name | ascii_downcase) == $repo and
-            (.base.repo.full_name | ascii_downcase) == $repo and .base.ref == $base
-          ' <<<"$pr_json" >/dev/null
+          bash .github/e2e/assert-candidate-binding.sh
           gh api "repos/$REPOSITORY/git/ref/heads/$DEFAULT_BRANCH" --jq .object.sha > "$current.main"
-          jq -cS '{
-            number,state,draft,
-            head:{repo:.head.repo.full_name,ref:.head.ref,sha:.head.sha},
-            base:{repo:.base.repo.full_name,ref:.base.ref,sha:.base.sha},
-            body:(.body // "")
-          }' <<<"$pr_json" > "$current.candidate"
-          gh api --paginate "repos/$REPOSITORY/issues/$CANDIDATE_PR/comments?per_page=100" \
-            --jq '.[] | {id,userId:.user.id,updatedAt:.updated_at,body}' \
-            | jq -cS . | sort > "$current.comments"
+          if [[ "$CANDIDATE_MODE" == "pull-request" ]]; then
+            pr_json="$(gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR")"
+            jq -cS '{
+              number,state,draft,
+              head:{repo:.head.repo.full_name,ref:.head.ref,sha:.head.sha},
+              base:{repo:.base.repo.full_name,ref:.base.ref,sha:.base.sha},
+              body:(.body // "")
+            }' <<<"$pr_json" > "$current.candidate"
+            gh api --paginate "repos/$REPOSITORY/issues/$CANDIDATE_PR/comments?per_page=100" \
+              --jq '.[] | {id,userId:.user.id,updatedAt:.updated_at,body}' \
+              | jq -cS . | sort > "$current.comments"
+          else
+            jq -cn --arg mode "$CANDIDATE_MODE" --arg sha "$CANDIDATE_SHA" \
+              '{mode:$mode,sha:$sha}' > "$current.candidate"
+            : > "$current.comments"
+          fi
           gh api --paginate "repos/$REPOSITORY/git/matching-refs/heads/dsh/task-?per_page=100" \
             --jq '.[] | [.ref,.object.type,.object.sha] | @tsv' | sort > "$current.task-refs"
           gh api --paginate "repos/$REPOSITORY/pulls?state=all&per_page=100" --jq '
@@ -1126,6 +1166,7 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           HARNESS_SHA: ${{ needs.gate.outputs.harness_sha }}
+          CANDIDATE_MODE: ${{ needs.gate.outputs.candidate_mode }}
           CANDIDATE_SHA: ${{ needs.gate.outputs.candidate_sha }}
           CANDIDATE_PR: ${{ needs.gate.outputs.pull_request }}
         run: |
@@ -1136,17 +1177,14 @@ jobs:
           ! git -C candidate-action config --local --get-regexp '^(http\..*\.extraheader|credential\.)' >/dev/null 2>&1
           node --check .github/e2e/github-integration-llm.mjs
           node --check .github/e2e/read-action-output.mjs
+          bash -n .github/e2e/assert-candidate-binding.sh
 
           gh api "repos/$REPOSITORY" > "$RUNNER_TEMP/dsh-e2e-integration-repository.json"
-          candidate_json="$(gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR")"
-          jq -e --arg sha "$CANDIDATE_SHA" --arg repo "${REPOSITORY,,}" --arg base "$DEFAULT_BRANCH" '
-            .state == "open" and .draft == false and .head.sha == $sha and
-            (.head.repo.full_name | ascii_downcase) == $repo and
-            (.base.repo.full_name | ascii_downcase) == $repo and .base.ref == $base
-          ' <<<"$candidate_json" >/dev/null
+          bash .github/e2e/assert-candidate-binding.sh
 
+          if [[ "$CANDIDATE_MODE" == "pull-request" ]]; then ci_event="pull_request"; else ci_event="push"; fi
           runs="$(gh api --method GET "repos/$REPOSITORY/actions/runs" \
-            -f head_sha="$CANDIDATE_SHA" -f event=pull_request -f status=completed -f per_page=50)"
+            -f head_sha="$CANDIDATE_SHA" -f event="$ci_event" -f status=completed -f per_page=50)"
           ci_run_id="$(jq -r '[.workflow_runs[] | select(.name == "CI" and .conclusion == "success")][0].id // empty' <<<"$runs")"
           [[ "$ci_run_id" =~ ^[1-9][0-9]*$ ]]
           [[ "$(gh api "repos/$REPOSITORY/actions/runs/$ci_run_id" --jq .head_sha)" == "$CANDIDATE_SHA" ]]
@@ -1163,6 +1201,14 @@ jobs:
         run: |
           set -euo pipefail
           marker="<!-- dsh-e2e:github-integration:v1 run=$GITHUB_RUN_ID attempt=$GITHUB_RUN_ATTEMPT candidate=$CANDIDATE_SHA -->"
+          label="dsh-e2e-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          label_description="Run-bound Core E2E fixture $GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT"
+          echo "label=$label" >> "$GITHUB_OUTPUT"
+          label_json="$(gh api --method POST "repos/$REPOSITORY/labels" \
+            -f name="$label" -f color=5319e7 -f description="$label_description")"
+          jq -e --arg name "$label" --arg description "$label_description" '
+            .name == $name and .color == "5319e7" and .description == $description
+          ' <<<"$label_json" >/dev/null
           issue_title="DSH E2E GitHub integration $GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT"
           issue_body="$(printf '%s\n\n%s' "$marker" "Temporary Issue owned by the trusted GitHub integration harness.")"
           issue_json="$(gh api --method POST "repos/$REPOSITORY/issues" -f title="$issue_title" -f body="$issue_body")"
@@ -1174,7 +1220,7 @@ jobs:
           jq -e --argjson number "$issue_number" --argjson id "$issue_id" --arg title "$issue_title" --arg body "$issue_body" '
             .number == $number and .id == $id and .state == "open" and
             (has("pull_request") | not) and .user.id == 41898282 and
-            .title == $title and .body == $body
+            .title == $title and .body == $body and .labels == [] and .assignees == []
           ' <<<"$issue_json" >/dev/null
 
           history="DSH_E2E_HISTORY_HIDDEN_$GITHUB_RUN_ID"
@@ -1184,14 +1230,32 @@ jobs:
           echo "history_id=$history_id" >> "$GITHUB_OUTPUT"
 
           branch="dsh-e2e/checks-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          fixture_path=".github/dsh-e2e-fixtures/checks-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT.txt"
+          fixture_content="DSH E2E checks fixture $GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT"
           [[ "$branch" =~ ^dsh-e2e/checks-[1-9][0-9]*-[1-9][0-9]*$ ]]
+          [[ "$fixture_path" =~ ^\.github/dsh-e2e-fixtures/checks-[1-9][0-9]*-[1-9][0-9]*\.txt$ ]]
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "fixture_path=$fixture_path" >> "$GITHUB_OUTPUT"
           if gh api "repos/$REPOSITORY/git/ref/heads/$branch" >/dev/null 2>&1; then
             echo "The isolated checks branch already exists" >&2
             exit 1
           fi
-          gh api --method POST "repos/$REPOSITORY/git/refs" -f ref="refs/heads/$branch" -f sha="$CANDIDATE_SHA" >/dev/null
-          [[ "$(gh api "repos/$REPOSITORY/git/ref/heads/$branch" --jq .object.sha)" == "$CANDIDATE_SHA" ]]
-          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          blob_sha="$(jq -cn --arg content "$fixture_content" '{content:$content,encoding:"utf-8"}' \
+            | gh api --method POST "repos/$REPOSITORY/git/blobs" --input - --jq .sha)"
+          base_tree_sha="$(gh api "repos/$REPOSITORY/git/commits/$CANDIDATE_SHA" --jq .tree.sha)"
+          tree_sha="$(jq -cn --arg base "$base_tree_sha" --arg path "$fixture_path" --arg sha "$blob_sha" \
+            '{base_tree:$base,tree:[{path:$path,mode:"100644",type:"blob",sha:$sha}]}' \
+            | gh api --method POST "repos/$REPOSITORY/git/trees" --input - --jq .sha)"
+          commit_message="DSH E2E checks fixture $GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT"
+          head_sha="$(jq -cn --arg message "$commit_message" --arg tree "$tree_sha" --arg parent "$CANDIDATE_SHA" \
+            '{message:$message,tree:$tree,parents:[$parent]}' \
+            | gh api --method POST "repos/$REPOSITORY/git/commits" --input - --jq .sha)"
+          [[ "$blob_sha" =~ ^[a-f0-9]{40}$ && "$base_tree_sha" =~ ^[a-f0-9]{40}$ ]]
+          [[ "$tree_sha" =~ ^[a-f0-9]{40}$ && "$head_sha" =~ ^[a-f0-9]{40}$ ]]
+          echo "tree_sha=$tree_sha" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          gh api --method POST "repos/$REPOSITORY/git/refs" -f ref="refs/heads/$branch" -f sha="$head_sha" >/dev/null
+          [[ "$(gh api "repos/$REPOSITORY/git/ref/heads/$branch" --jq .object.sha)" == "$head_sha" ]]
 
           pr_title="DSH E2E checks $GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT"
           pr_body="$(printf '%s\n\n%s' "$marker" "Temporary draft PR owned by the trusted GitHub integration harness.")"
@@ -1203,11 +1267,11 @@ jobs:
           echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
           echo "pr_id=$pr_id" >> "$GITHUB_OUTPUT"
           jq -e --argjson number "$pr_number" --argjson id "$pr_id" --arg repo "${REPOSITORY,,}" \
-            --arg branch "$branch" --arg base "$DEFAULT_BRANCH" --arg sha "$CANDIDATE_SHA" \
-            --arg title "$pr_title" --arg body "$pr_body" '
+            --arg branch "$branch" --arg base "$DEFAULT_BRANCH" --arg sha "$head_sha" \
+            --arg candidate "$CANDIDATE_SHA" --arg title "$pr_title" --arg body "$pr_body" '
             .number == $number and .id == $id and .state == "open" and .draft == true and
             (.head.repo.full_name | ascii_downcase) == $repo and .head.ref == $branch and .head.sha == $sha and
-            (.base.repo.full_name | ascii_downcase) == $repo and .base.ref == $base and
+            (.base.repo.full_name | ascii_downcase) == $repo and .base.ref == $base and .base.sha == $candidate and
             .title == $title and .body == $body
           ' <<<"$pr_json" >/dev/null
 
@@ -1221,23 +1285,30 @@ jobs:
           CANDIDATE_SHA: ${{ needs.gate.outputs.candidate_sha }}
           ISSUE_NUMBER: ${{ steps.integration_entities.outputs.issue_number }}
           ISSUE_ID: ${{ steps.integration_entities.outputs.issue_id }}
+          ISSUE_LABEL: ${{ steps.integration_entities.outputs.label }}
           HISTORY_ID: ${{ steps.integration_entities.outputs.history_id }}
           CHECKS_PR: ${{ steps.integration_entities.outputs.pr_number }}
+          CHECKS_HEAD: ${{ steps.integration_entities.outputs.head_sha }}
           CI_RUN_ID: ${{ steps.integration_baseline.outputs.ci_run_id }}
         run: |
           set -euo pipefail
           [[ "$ISSUE_NUMBER" =~ ^[1-9][0-9]*$ ]]
           [[ "$ISSUE_ID" =~ ^[1-9][0-9]*$ ]]
+          [[ "$ISSUE_LABEL" =~ ^dsh-e2e-[1-9][0-9]*-[1-9][0-9]*$ ]]
           [[ "$HISTORY_ID" =~ ^[1-9][0-9]*$ ]]
           [[ "$CHECKS_PR" =~ ^[1-9][0-9]*$ ]]
+          [[ "$CHECKS_HEAD" =~ ^[a-f0-9]{40}$ ]]
           [[ "$CI_RUN_ID" =~ ^[1-9][0-9]*$ ]]
 
           audit="$RUNNER_TEMP/dsh-e2e-github-audit.jsonl"
           fixture_info="$RUNNER_TEMP/dsh-e2e-github-fixture.json"
           fixture_log="$RUNNER_TEMP/dsh-e2e-github-fixture.log"
           fixture_key="sk-dsh-e2e-fixture-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          mutated_pull_title="DSH E2E checks updated $GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT"
           : > "$audit"
           DSH_E2E_GITHUB_AUDIT="$audit" DSH_E2E_FIXTURE_KEY="$fixture_key" \
+            DSH_E2E_ISSUE_LABEL="$ISSUE_LABEL" DSH_E2E_ISSUE_ASSIGNEE="$GITHUB_ACTOR" \
+            DSH_E2E_PULL_TITLE="$mutated_pull_title" \
             node .github/e2e/github-integration-llm.mjs > "$fixture_info" 2> "$fixture_log" &
           fixture_pid=$!
           cleanup_fixture() {
@@ -1264,11 +1335,18 @@ jobs:
             {action:"assigned",repository:$repository[0],sender:{login:$actor},issue:$issue[0],assignee:{login:"dsh-e2e-assignee"}}
           ' > "$RUNNER_TEMP/dsh-e2e-assignee-event.json"
           trigger_id=$((HISTORY_ID + 1000000))
-          trigger_body="$(printf '%s\n%s\n%s' "/deepseek task --write exercise the typed GitHub comment tool" "DSH_E2E_TRIGGER_VISIBLE_$GITHUB_RUN_ID" "![attachment](https://github.com/user-attachments/assets/dsh-e2e-must-not-forward)")"
+          trigger_body="$(printf '%s\n%s\n%s\n%s\n%s\n%s\n%s' \
+            "/deepseek task --write exercise the typed GitHub comment tool" \
+            "DSH_E2E_TRIGGER_VISIBLE_$GITHUB_RUN_ID" \
+            "![attachment](https://github.com/user-attachments/assets/dsh-e2e-inline-must-not-forward)" \
+            "![reference][dsh-e2e-reference]" \
+            "[dsh-e2e-reference]: https://github.com/user-attachments/assets/dsh-e2e-reference-must-not-forward" \
+            '<picture><source srcset="https://github.com/user-attachments/assets/dsh-e2e-source-must-not-forward"><img src="https://github.com/user-attachments/assets/dsh-e2e-html-must-not-forward"></picture>' \
+            "https://github.com/user-attachments/assets/dsh-e2e-raw-must-not-forward")"
           jq -n --slurpfile repository "$repository_file" --slurpfile issue "$issue_file" \
             --arg actor "$actor" --arg body "$trigger_body" --argjson trigger_id "$trigger_id" '
             {action:"created",repository:$repository[0],sender:{login:$actor},issue:$issue[0],comment:{
-              id:$trigger_id,body:$body,created_at:"2099-01-01T00:00:00Z",updated_at:"2099-01-01T00:00:00Z",user:{login:"github-actions[bot]"}
+              id:$trigger_id,body:$body,created_at:"2099-01-01T00:00:00Z",updated_at:"2099-01-01T00:00:00Z",user:{login:$actor}
             }}
           ' > "$RUNNER_TEMP/dsh-e2e-github-event.json"
           jq -n --slurpfile repository "$repository_file" --slurpfile pull "$pr_file" --arg actor "$actor" '
@@ -1334,36 +1412,49 @@ jobs:
           run_candidate github issue_comment "$RUNNER_TEMP/dsh-e2e-github-event.json" github \
             'INPUT_COMMAND=auto' 'INPUT_TRIGGER-PHRASE=/deepseek' \
             "INPUT_ALLOWED-ACTORS=$actor" 'INPUT_INCLUDE-COMMENTS-BY-ACTOR=*' \
-            'INPUT_EXCLUDE-COMMENTS-BY-ACTOR=github-actions[bot]' \
+            "INPUT_EXCLUDE-COMMENTS-BY-ACTOR=$actor,github-actions[bot]" \
             'INPUT_PERMISSION-PROFILE=custom' \
-            'INPUT_ALLOWED-TOOLS=["workspace.edit","github.comment.create"]' \
+            'INPUT_ALLOWED-TOOLS=["workspace.edit","github.issue.labels.set","github.issue.assignees.set","github.comment.create","github.issue.state.update"]' \
             'INPUT_ALLOW-WRITE=true' 'INPUT_RUN-TESTS=true' \
             'INPUT_VALIDATION-INTEGRITY=strict' \
             'INPUT_TEST-COMMANDS=[["node","-e","process.exit(0)"]]' \
-            "INPUT_TASK-OUTPUT-SCHEMA=$task_schema" 'INPUT_MAX-TURNS=2'
+            "INPUT_TASK-OUTPUT-SCHEMA=$task_schema" 'INPUT_MAX-TURNS=5'
           github_result="$(read_output github result-json)"
           github_task="$(read_output github task-output)"
           jq -e '
             .conclusion == "success" and .operation == "task" and .policy.trust == "trusted-write" and
             .validation.status == "passed" and .validation.commandCount == 1 and
             .write.status == "no-changes" and .taskOutput == {route:"github",accepted:true} and
+            ([.loop.toolReceipts[] | select(.id == "github.issue.labels.set" and .ok == true and .effect == "updated" and .attempts >= 1 and (.reconciled | type) == "boolean")] | length == 1) and
+            ([.loop.toolReceipts[] | select(.id == "github.issue.assignees.set" and .ok == true and .effect == "updated" and .attempts >= 1 and (.reconciled | type) == "boolean")] | length == 1) and
             (.loop.toolReceipts | any(
               .id == "github.comment.create" and .ok == true and .effect == "created" and .reconciled == true and .attempts >= 1
-            ))
+            )) and
+            ([.loop.toolReceipts[] | select(.id == "github.issue.state.update" and .ok == true and .effect == "updated" and .attempts >= 1 and (.reconciled | type) == "boolean")] | length == 1) and
+            ([.loop.toolReceipts[] | select(.id | startswith("github."))] | length == 4)
           ' <<<"$github_result" >/dev/null
           jq -e '. == {route:"github",accepted:true}' <<<"$github_task" >/dev/null
 
           history="DSH_E2E_HISTORY_HIDDEN_$GITHUB_RUN_ID"
           trigger="DSH_E2E_TRIGGER_VISIBLE_$GITHUB_RUN_ID"
-          attachment_url="https://github.com/user-attachments/assets/dsh-e2e-must-not-forward"
-          jq -s -e --arg history "$history" --arg trigger "$trigger" --arg attachment "$attachment_url" '
+          inline_url="https://github.com/user-attachments/assets/dsh-e2e-inline-must-not-forward"
+          reference_url="https://github.com/user-attachments/assets/dsh-e2e-reference-must-not-forward"
+          source_url="https://github.com/user-attachments/assets/dsh-e2e-source-must-not-forward"
+          html_url="https://github.com/user-attachments/assets/dsh-e2e-html-must-not-forward"
+          raw_url="https://github.com/user-attachments/assets/dsh-e2e-raw-must-not-forward"
+          jq -s -e --arg history "$history" --arg trigger "$trigger" \
+            --arg inline "$inline_url" --arg reference "$reference_url" --arg source "$source_url" \
+            --arg html "$html_url" --arg raw "$raw_url" '
             ([.[] | select(.route == "github" and .index == 1)] | length == 1) and
             ([.[] | select(.route == "github" and .index == 1)][0] |
               .authorizationMatches == true and
               (.prompt | contains($trigger)) and
               ((.prompt | contains($history)) | not) and
               (.prompt | contains("[image removed]")) and
-              ((.prompt | contains($attachment)) | not))
+              (.prompt as $prompt | [$inline,$reference,$source,$html,$raw] | all(. as $url;
+                ($prompt | contains($url) | not) and
+                ($prompt | contains(($url | split("/") | last)) | not)
+              )))
           ' "$audit" >/dev/null
           tool_comments="$(gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100")"
           jq -e '
@@ -1372,6 +1463,39 @@ jobs:
             ($tools[0].body | contains("DSH E2E typed GitHub tool completed")) and
             (($tools[0].body | contains("@maintainers")) | not)
           ' <<<"$tool_comments" >/dev/null
+
+          mutated_issue="$(gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER")"
+          jq -e --arg label "$ISSUE_LABEL" --arg actor "$actor" '
+            .state == "closed" and .state_reason == "completed" and
+            [.labels[].name] == [$label] and [.assignees[].login] == [$actor]
+          ' <<<"$mutated_issue" >/dev/null
+          jq -cn '{state:"open",state_reason:"reopened",labels:[],assignees:[]}' \
+            | gh api --method PATCH "repos/$REPOSITORY/issues/$ISSUE_NUMBER" --input - >/dev/null
+          gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER" \
+            | jq -e '.state == "open" and .labels == [] and .assignees == []' >/dev/null
+
+          run_candidate metadata pull_request "$RUNNER_TEMP/dsh-e2e-checks-event.json" metadata \
+            'INPUT_COMMAND=task' 'INPUT_PROMPT=Update the bound draft PR metadata exactly as requested.' \
+            'INPUT_TASK-ACCESS=write' "INPUT_ALLOWED-ACTORS=$actor" \
+            'INPUT_PERMISSION-PROFILE=custom' \
+            'INPUT_ALLOWED-TOOLS=["workspace.edit","github.pull.metadata.update"]' \
+            'INPUT_ALLOW-WRITE=true' 'INPUT_RUN-TESTS=true' \
+            'INPUT_VALIDATION-INTEGRITY=strict' \
+            'INPUT_TEST-COMMANDS=[["node","-e","process.exit(0)"]]' 'INPUT_MAX-TURNS=2'
+          metadata_result="$(read_output metadata result-json)"
+          jq -e '
+            .conclusion == "success" and .operation == "task" and .policy.trust == "trusted-write" and
+            .validation.status == "passed" and .write.status == "no-changes" and
+            ([.loop.toolReceipts[] | select(
+              .id == "github.pull.metadata.update" and .ok == true and .effect == "updated" and
+              .attempts >= 1 and (.reconciled | type) == "boolean"
+            )] | length == 1)
+          ' <<<"$metadata_result" >/dev/null
+          [[ "$(gh api "repos/$REPOSITORY/pulls/$CHECKS_PR" --jq .title)" == "$mutated_pull_title" ]]
+          original_pull_title="DSH E2E checks $GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT"
+          gh api --method PATCH "repos/$REPOSITORY/pulls/$CHECKS_PR" -f title="$original_pull_title" >/dev/null
+          [[ "$(gh api "repos/$REPOSITORY/pulls/$CHECKS_PR" --jq .title)" == "$original_pull_title" ]]
+          [[ "$(gh api "repos/$REPOSITORY/pulls/$CHECKS_PR" --jq .head.sha)" == "$CHECKS_HEAD" ]]
 
           run_candidate checks pull_request "$RUNNER_TEMP/dsh-e2e-checks-event.json" checks \
             'INPUT_COMMAND=diagnose' 'INPUT_PERMISSION-PROFILE=custom' \
@@ -1383,10 +1507,11 @@ jobs:
           ' <<<"$checks_result" >/dev/null
 
           jq -s -e '
-            length == 6 and all(.authorizationMatches == true) and
+            length == 11 and all(.authorizationMatches == true) and
             ([.[] | select(.route == "label")] | length == 1) and
             ([.[] | select(.route == "assignee")] | length == 1) and
-            ([.[] | select(.route == "github")] | length == 2) and
+            ([.[] | select(.route == "github")] | length == 5) and
+            ([.[] | select(.route == "metadata")] | length == 2) and
             ([.[] | select(.route == "checks")] | length == 2)
           ' "$audit" >/dev/null
 
@@ -1397,72 +1522,138 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          CANDIDATE_MODE: ${{ needs.gate.outputs.candidate_mode }}
           CANDIDATE_SHA: ${{ needs.gate.outputs.candidate_sha }}
           CANDIDATE_PR: ${{ needs.gate.outputs.pull_request }}
+          ISSUE_LABEL: ${{ steps.integration_entities.outputs.label }}
           ISSUE_NUMBER: ${{ steps.integration_entities.outputs.issue_number }}
           ISSUE_ID: ${{ steps.integration_entities.outputs.issue_id }}
           CHECKS_BRANCH: ${{ steps.integration_entities.outputs.branch }}
+          CHECKS_TREE: ${{ steps.integration_entities.outputs.tree_sha }}
+          CHECKS_HEAD: ${{ steps.integration_entities.outputs.head_sha }}
+          FIXTURE_PATH: ${{ steps.integration_entities.outputs.fixture_path }}
           CHECKS_PR: ${{ steps.integration_entities.outputs.pr_number }}
           CHECKS_PR_ID: ${{ steps.integration_entities.outputs.pr_id }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
+          cleanup_failures=0
+          record_failure() {
+            echo "::error::Integration cleanup failed for $1; no unverified or broad deletion was attempted."
+            cleanup_failures=$((cleanup_failures + 1))
+          }
           marker="<!-- dsh-e2e:github-integration:v1 run=$GITHUB_RUN_ID attempt=$GITHUB_RUN_ATTEMPT candidate=$CANDIDATE_SHA -->"
           issue_title="DSH E2E GitHub integration $GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT"
           issue_body="$(printf '%s\n\n%s' "$marker" "Temporary Issue owned by the trusted GitHub integration harness.")"
-          [[ "$ISSUE_NUMBER" =~ ^[1-9][0-9]*$ && "$ISSUE_ID" =~ ^[1-9][0-9]*$ ]]
-          issue_json="$(gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER")"
-          jq -e --argjson number "$ISSUE_NUMBER" --argjson id "$ISSUE_ID" --arg title "$issue_title" --arg body "$issue_body" '
-            .number == $number and .id == $id and (has("pull_request") | not) and
-            .user.id == 41898282 and .title == $title and .body == $body
-          ' <<<"$issue_json" >/dev/null
-          issue_comments="$(gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100")"
-          jq -e 'all(.[]; .user.id == 41898282)' <<<"$issue_comments" >/dev/null
-          mapfile -t issue_comment_ids < <(jq -r '.[].id' <<<"$issue_comments")
-          for comment_id in "${issue_comment_ids[@]}"; do
-            [[ "$comment_id" =~ ^[1-9][0-9]*$ ]]
-            gh api --method DELETE "repos/$REPOSITORY/issues/comments/$comment_id"
-          done
-          gh api --method PATCH "repos/$REPOSITORY/issues/$ISSUE_NUMBER" -f state=closed >/dev/null
-          [[ "$(gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER" --jq .state)" == "closed" ]]
-          [[ "$(gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100" --jq length)" -eq 0 ]]
-
-          [[ "$CHECKS_BRANCH" =~ ^dsh-e2e/checks-[1-9][0-9]*-[1-9][0-9]*$ ]]
-          [[ "$CHECKS_PR" =~ ^[1-9][0-9]*$ && "$CHECKS_PR_ID" =~ ^[1-9][0-9]*$ ]]
           pr_title="DSH E2E checks $GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT"
+          mutated_pr_title="DSH E2E checks updated $GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT"
           pr_body="$(printf '%s\n\n%s' "$marker" "Temporary draft PR owned by the trusted GitHub integration harness.")"
-          pr_json="$(gh api "repos/$REPOSITORY/pulls/$CHECKS_PR")"
-          jq -e --argjson number "$CHECKS_PR" --argjson id "$CHECKS_PR_ID" --arg repo "${REPOSITORY,,}" \
-            --arg branch "$CHECKS_BRANCH" --arg base "$DEFAULT_BRANCH" --arg sha "$CANDIDATE_SHA" \
-            --arg title "$pr_title" --arg body "$pr_body" '
-            .number == $number and .id == $id and .state == "open" and .draft == true and
-            (.head.repo.full_name | ascii_downcase) == $repo and .head.ref == $branch and .head.sha == $sha and
-            (.base.repo.full_name | ascii_downcase) == $repo and .base.ref == $base and
-            .title == $title and .body == $body
-          ' <<<"$pr_json" >/dev/null
-          pr_comments="$(gh api "repos/$REPOSITORY/issues/$CHECKS_PR/comments?per_page=100")"
-          jq -e 'all(.[]; .user.id == 41898282)' <<<"$pr_comments" >/dev/null
-          mapfile -t pr_comment_ids < <(jq -r '.[].id' <<<"$pr_comments")
-          for comment_id in "${pr_comment_ids[@]}"; do
-            [[ "$comment_id" =~ ^[1-9][0-9]*$ ]]
-            gh api --method DELETE "repos/$REPOSITORY/issues/comments/$comment_id"
-          done
-          [[ "$(gh api "repos/$REPOSITORY/git/ref/heads/$CHECKS_BRANCH" --jq .object.sha)" == "$CANDIDATE_SHA" ]]
-          gh api --method PATCH "repos/$REPOSITORY/pulls/$CHECKS_PR" -f state=closed >/dev/null
-          gh api --method DELETE "repos/$REPOSITORY/git/refs/heads/$CHECKS_BRANCH"
-          [[ "$(gh api "repos/$REPOSITORY/pulls/$CHECKS_PR" --jq .state)" == "closed" ]]
-          if gh api "repos/$REPOSITORY/git/ref/heads/$CHECKS_BRANCH" >/dev/null 2>&1; then
-            echo "Verified integration checks branch still exists" >&2
-            exit 1
+
+          cleanup_issue() (
+            set -euo pipefail
+            [[ "$ISSUE_NUMBER" =~ ^[1-9][0-9]*$ ]]
+            [[ -z "$ISSUE_ID" || "$ISSUE_ID" =~ ^[1-9][0-9]*$ ]]
+            issue_json="$(gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER")"
+            actual_issue_id="$(jq -r .id <<<"$issue_json")"
+            [[ "$actual_issue_id" =~ ^[1-9][0-9]*$ ]]
+            [[ -z "$ISSUE_ID" || "$ISSUE_ID" == "$actual_issue_id" ]]
+            jq -e --argjson number "$ISSUE_NUMBER" --arg title "$issue_title" --arg body "$issue_body" '
+              .number == $number and (has("pull_request") | not) and
+              .user.id == 41898282 and .title == $title and .body == $body
+            ' <<<"$issue_json" >/dev/null
+            jq -cn '{state:"open",state_reason:"reopened",labels:[],assignees:[]}' \
+              | gh api --method PATCH "repos/$REPOSITORY/issues/$ISSUE_NUMBER" --input - >/dev/null
+            issue_comments="$(gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100")"
+            jq -e 'all(.[]; .user.id == 41898282)' <<<"$issue_comments" >/dev/null
+            mapfile -t comment_ids < <(jq -r '.[].id' <<<"$issue_comments")
+            for comment_id in "${comment_ids[@]}"; do
+              [[ "$comment_id" =~ ^[1-9][0-9]*$ ]]
+              gh api --method DELETE "repos/$REPOSITORY/issues/comments/$comment_id"
+            done
+            gh api --method PATCH "repos/$REPOSITORY/issues/$ISSUE_NUMBER" -f state=closed >/dev/null
+            [[ "$(gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER" --jq .state)" == "closed" ]]
+            [[ "$(gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100" --jq length)" -eq 0 ]]
+          )
+
+          cleanup_label() (
+            set -euo pipefail
+            [[ "$ISSUE_LABEL" =~ ^dsh-e2e-[1-9][0-9]*-[1-9][0-9]*$ ]]
+            label_json="$(gh api "repos/$REPOSITORY/labels/$ISSUE_LABEL" 2>/dev/null)" || return 0
+            label_description="Run-bound Core E2E fixture $GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT"
+            jq -e --arg name "$ISSUE_LABEL" --arg description "$label_description" '
+              .name == $name and .color == "5319e7" and .description == $description
+            ' <<<"$label_json" >/dev/null
+            gh api --method DELETE "repos/$REPOSITORY/labels/$ISSUE_LABEL"
+          )
+
+          cleanup_pull() (
+            set -euo pipefail
+            [[ "$CHECKS_PR" =~ ^[1-9][0-9]*$ ]]
+            [[ -z "$CHECKS_PR_ID" || "$CHECKS_PR_ID" =~ ^[1-9][0-9]*$ ]]
+            [[ "$CHECKS_BRANCH" =~ ^dsh-e2e/checks-[1-9][0-9]*-[1-9][0-9]*$ ]]
+            pr_json="$(gh api "repos/$REPOSITORY/pulls/$CHECKS_PR")"
+            actual_pr_id="$(jq -r .id <<<"$pr_json")"
+            expected_head="$CHECKS_HEAD"
+            [[ "$actual_pr_id" =~ ^[1-9][0-9]*$ ]]
+            [[ -z "$CHECKS_PR_ID" || "$CHECKS_PR_ID" == "$actual_pr_id" ]]
+            if [[ -z "$expected_head" ]]; then expected_head="$(jq -r .head.sha <<<"$pr_json")"; fi
+            [[ "$expected_head" =~ ^[a-f0-9]{40}$ ]]
+            jq -e --argjson number "$CHECKS_PR" --arg repo "${REPOSITORY,,}" \
+              --arg branch "$CHECKS_BRANCH" --arg base "$DEFAULT_BRANCH" --arg sha "$expected_head" \
+              --arg candidate "$CANDIDATE_SHA" --arg title "$pr_title" --arg mutated "$mutated_pr_title" --arg body "$pr_body" '
+              .number == $number and .state == "open" and .draft == true and
+              (.head.repo.full_name | ascii_downcase) == $repo and .head.ref == $branch and .head.sha == $sha and
+              (.base.repo.full_name | ascii_downcase) == $repo and .base.ref == $base and .base.sha == $candidate and
+              (.title == $title or .title == $mutated) and .body == $body
+            ' <<<"$pr_json" >/dev/null
+            gh api --method PATCH "repos/$REPOSITORY/pulls/$CHECKS_PR" -f title="$pr_title" >/dev/null
+            pr_comments="$(gh api "repos/$REPOSITORY/issues/$CHECKS_PR/comments?per_page=100")"
+            jq -e 'all(.[]; .user.id == 41898282)' <<<"$pr_comments" >/dev/null
+            mapfile -t comment_ids < <(jq -r '.[].id' <<<"$pr_comments")
+            for comment_id in "${comment_ids[@]}"; do
+              [[ "$comment_id" =~ ^[1-9][0-9]*$ ]]
+              gh api --method DELETE "repos/$REPOSITORY/issues/comments/$comment_id"
+            done
+            gh api --method PATCH "repos/$REPOSITORY/pulls/$CHECKS_PR" -f state=closed >/dev/null
+            [[ "$(gh api "repos/$REPOSITORY/pulls/$CHECKS_PR" --jq .state)" == "closed" ]]
+          )
+
+          cleanup_branch() (
+            set -euo pipefail
+            [[ "$CHECKS_BRANCH" =~ ^dsh-e2e/checks-[1-9][0-9]*-[1-9][0-9]*$ ]]
+            [[ "$FIXTURE_PATH" =~ ^\.github/dsh-e2e-fixtures/checks-[1-9][0-9]*-[1-9][0-9]*\.txt$ ]]
+            ref_sha="$(gh api "repos/$REPOSITORY/git/ref/heads/$CHECKS_BRANCH" --jq .object.sha 2>/dev/null)" || return 0
+            [[ "$ref_sha" =~ ^[a-f0-9]{40}$ ]]
+            [[ -z "$CHECKS_HEAD" || "$ref_sha" == "$CHECKS_HEAD" ]]
+            commit_json="$(gh api "repos/$REPOSITORY/git/commits/$ref_sha")"
+            [[ "$(jq -r '.parents | length' <<<"$commit_json")" -eq 1 ]]
+            [[ "$(jq -r '.parents[0].sha' <<<"$commit_json")" == "$CANDIDATE_SHA" ]]
+            [[ "$CHECKS_TREE" =~ ^[a-f0-9]{40}$ && "$(jq -r .tree.sha <<<"$commit_json")" == "$CHECKS_TREE" ]]
+            [[ "$(jq -r .message <<<"$commit_json")" == "DSH E2E checks fixture $GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT" ]]
+            gh api "repos/$REPOSITORY/compare/$CANDIDATE_SHA...$ref_sha" \
+              | jq -e --arg path "$FIXTURE_PATH" '.files | length == 1 and .[0].filename == $path and .[0].status == "added"' >/dev/null
+            content="$(gh api "repos/$REPOSITORY/contents/$FIXTURE_PATH?ref=$ref_sha" --jq .content | tr -d '\n' | base64 --decode)"
+            [[ "$content" == "DSH E2E checks fixture $GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT" ]]
+            gh api --method DELETE "repos/$REPOSITORY/git/refs/heads/$CHECKS_BRANCH"
+            if gh api "repos/$REPOSITORY/git/ref/heads/$CHECKS_BRANCH" >/dev/null 2>&1; then return 1; fi
+          )
+
+          if [[ -n "$ISSUE_NUMBER" || -n "$ISSUE_ID" ]]; then
+            cleanup_issue; status=$?; if [[ "$status" -ne 0 ]]; then record_failure issue; fi
+          fi
+          if [[ -n "$ISSUE_LABEL" ]]; then
+            cleanup_label; status=$?; if [[ "$status" -ne 0 ]]; then record_failure label; fi
+          fi
+          if [[ -n "$CHECKS_PR" || -n "$CHECKS_PR_ID" ]]; then
+            cleanup_pull; status=$?; if [[ "$status" -ne 0 ]]; then record_failure pull-request; fi
+          fi
+          if [[ -n "$CHECKS_BRANCH" || -n "$CHECKS_HEAD" || -n "$FIXTURE_PATH" ]]; then
+            cleanup_branch; status=$?; if [[ "$status" -ne 0 ]]; then record_failure branch; fi
           fi
 
-          candidate_json="$(gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR")"
-          jq -e --arg sha "$CANDIDATE_SHA" --arg repo "${REPOSITORY,,}" --arg base "$DEFAULT_BRANCH" '
-            .state == "open" and .draft == false and .head.sha == $sha and
-            (.head.repo.full_name | ascii_downcase) == $repo and
-            (.base.repo.full_name | ascii_downcase) == $repo and .base.ref == $base
-          ' <<<"$candidate_json" >/dev/null
-          ! git -C . config --local --get-regexp '^(http\..*\.extraheader|credential\.)' >/dev/null 2>&1
-          ! git -C candidate-action config --local --get-regexp '^(http\..*\.extraheader|credential\.)' >/dev/null 2>&1
+          bash .github/e2e/assert-candidate-binding.sh || record_failure candidate-binding
+          ! git -C . config --local --get-regexp '^(http\..*\.extraheader|credential\.)' >/dev/null 2>&1 || record_failure harness-credentials
+          ! git -C candidate-action config --local --get-regexp '^(http\..*\.extraheader|credential\.)' >/dev/null 2>&1 || record_failure candidate-credentials
+          [[ "$cleanup_failures" -eq 0 ]]
 
   revalidate_candidate:
     name: Final candidate binding
@@ -1471,21 +1662,32 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
+      contents: read
       pull-requests: read
     steps:
-      - name: Revalidate open same-repository candidate PR
+      - name: Revalidate exact candidate binding
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          CANDIDATE_MODE: ${{ needs.gate.outputs.candidate_mode }}
           CANDIDATE_SHA: ${{ needs.gate.outputs.candidate_sha }}
           CANDIDATE_PR: ${{ needs.gate.outputs.pull_request }}
         run: |
           set -euo pipefail
-          pr_json="$(gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR")"
-          jq -e --arg sha "$CANDIDATE_SHA" --arg repo "${REPOSITORY,,}" --arg base "$DEFAULT_BRANCH" '
-            .state == "open" and .draft == false and .head.sha == $sha and
-            (.head.repo.full_name | ascii_downcase) == $repo and
-            (.base.repo.full_name | ascii_downcase) == $repo and .base.ref == $base
-          ' <<<"$pr_json" >/dev/null
+          case "$CANDIDATE_MODE" in
+            pull-request)
+              pr_json="$(gh api "repos/$REPOSITORY/pulls/$CANDIDATE_PR")"
+              jq -e --arg sha "$CANDIDATE_SHA" --arg repo "${REPOSITORY,,}" --arg base "$DEFAULT_BRANCH" '
+                .state == "open" and .draft == false and .head.sha == $sha and
+                (.head.repo.full_name | ascii_downcase) == $repo and
+                (.base.repo.full_name | ascii_downcase) == $repo and .base.ref == $base
+              ' <<<"$pr_json" >/dev/null
+              ;;
+            main)
+              [[ -z "$CANDIDATE_PR" ]]
+              [[ "$(gh api "repos/$REPOSITORY/git/ref/heads/$DEFAULT_BRANCH" --jq .object.sha)" == "$CANDIDATE_SHA" ]]
+              ;;
+            *) exit 1 ;;
+          esac

--- a/docs/maintainer-release.md
+++ b/docs/maintainer-release.md
@@ -27,7 +27,7 @@ Before qualification, configure the `core-e2e` environment:
 2. Add `DEEPSEEK_API_KEY` to that environment.
 3. Do not expose the secret to the gate jobs; the workflows bind trusted identities before entering the environment.
 
-Core E2E uses repository variable `DSH_E2E_CANDIDATE_SHA`. The release canary uses `DSH_RELEASE_CANARY_SHA`. Each must be a lowercase, full 40-character commit SHA for its current purpose.
+Both pre-merge and post-merge Core E2E use repository variable `DSH_E2E_CANDIDATE_SHA`. The release canary uses `DSH_RELEASE_CANARY_SHA`. Each must be a lowercase, full 40-character commit SHA for its current purpose.
 
 ## Local qualification
 
@@ -39,6 +39,12 @@ npm run check
 ```
 
 `npm run check` runs formatting, lint, type checking, coverage tests, the release-contract check, the DSH configuration audit, and a deterministic `dist` build comparison. Do not skip a failing sub-check.
+
+For v0.6.0, the DSH audit also proves that the exact headless package still
+accepts only one text task and creates one text content block. That negative
+contract is release evidence for deferring GitHub attachment images; do not
+remove it unless a replacement exact DSH multimodal contract and its security
+review ship together.
 
 Before committing, inspect the complete diff and confirm that only intended source, test, metadata, documentation, and generated bundle changes are present. For a documentation-only PR, verify explicitly that `src/`, `dist/`, runtime assets, `action.yml`, and package files did not change.
 
@@ -90,15 +96,16 @@ The candidate PR must be open, non-draft, same-repository, and target the defaul
 The permanent [Core E2E workflow](../.github/workflows/e2e.yml) is trusted release harness code and must already exist on the live default branch. Its secretless gate requires a write-capable actor and binds all of the following before any secret-bearing job starts:
 
 - the workflow and dispatch SHA equal the live default-branch SHA;
-- `candidate_sha` is the current full PR head SHA;
+- `candidate_sha` is either the current full PR head SHA or, in protected post-merge mode, the live default-branch SHA;
 - `DSH_E2E_CANDIDATE_SHA` equals that SHA; and
-- the supplied PR is open, non-draft, same-repository, and based on the default branch.
+- pull-request mode binds an open, non-draft, same-repository PR based on the default branch, while main mode rejects a PR number and requires the candidate, dispatch, workflow, and live default-branch SHAs to be identical.
 
-Set the candidate variable, then dispatch the trusted workflow from `main`:
+For pre-merge qualification, set the candidate variable and dispatch the trusted workflow from `main` in pull-request mode:
 
 ```bash
 gh variable set DSH_E2E_CANDIDATE_SHA --body "$candidate_sha"
 gh workflow run e2e.yml --ref main \
+  -f candidate_mode=pull-request \
   -f candidate_sha="$candidate_sha" \
   -f pull_request="$pr_number"
 ```
@@ -117,9 +124,20 @@ The golden paths cover:
 | Subagent                    | Real `native.subagent` through a successful no-change write path                                                                                         |
 | Bash trusted write          | `standard` native Bash, validation, and exact branch/PR/commit/file assertions                                                                           |
 | Cancellation                | Graceful `SIGTERM` moves the isolated sticky comment from In progress to cancelled, then removes only the fixture comment and closes its temporary Issue |
+| Trigger and filters         | Deterministic label, assignee, custom phrase, actor deny, historical-comment exclusion, and triggering-comment retention                                 |
+| Branch UX                   | A real task PR targets the candidate branch and uses the configured sanitized prefix/template while retaining the Controller key                         |
+| Typed GitHub tools          | All six exact operations: labels, assignees, Issue state, reconciled comment creation, PR metadata, and immutable-head check/status reads                |
+| Structured task output      | Trusted bounded schema, final Controller validation, scalar output, and optional field inside the unchanged audit envelope                               |
+| Image boundary              | Inline/reference Markdown, HTML image/source, and raw GitHub attachment URLs/tokens are absent from the deterministic LLM request                        |
 | Credential isolation        | All candidate and harness checkouts use `persist-credentials: false` and have no residual Git auth configuration                                         |
 
-The workflow also compares `main`, the candidate PR, comments, `dsh/task-*` refs, and Controller-created task PRs on no-mutation paths, then revalidates the candidate identity at the end.
+The workflow also compares `main`, the candidate identity, PR/comments when
+present, legacy `dsh/task-*` refs, and Controller-created task PRs on
+no-mutation paths. Its
+run-bound label, Issue, draft PR, comments, one-file fixture commit, and custom
+ref are identity-verified and removed exactly before final candidate
+revalidation. Cleanup handles each emitted identity independently, continues
+after a per-fixture failure, and never performs a broad deletion.
 
 Graceful cancellation is the verifiable path. `SIGKILL`, runner/host loss, a process crash, or GitHub API/network loss can prevent all finalizers from running; Core E2E must not claim otherwise.
 
@@ -127,15 +145,28 @@ If Core E2E finds a bug, fix it on the PR, obtain the new head SHA, update the v
 
 ## Merge and qualify `main`
 
-After candidate CI and Core E2E pass:
+After candidate CI and pre-merge Core E2E pass:
 
 1. Reconfirm the PR head SHA has not moved.
 2. Merge the PR into `main`.
-3. Record the resulting full `main` SHA.
+3. Record the resulting full `main` SHA as `release_sha`.
 4. Wait for the `push` CI run on that exact `main` SHA.
 5. Verify the working tree and release metadata contain the expected version and generated bundle.
+6. Set `DSH_E2E_CANDIDATE_SHA` to `release_sha` and run the complete protected Core E2E workflow in `main` mode:
 
-Do not tag while the final `main` CI is pending or failing.
+   ```bash
+   gh variable set DSH_E2E_CANDIDATE_SHA --body "$release_sha"
+   gh workflow run e2e.yml --ref main \
+     -f candidate_mode=main \
+     -f candidate_sha="$release_sha"
+   ```
+
+7. Wait for every Core E2E job, including final candidate binding, to succeed against that exact SHA.
+
+Do not tag while final `main` CI or post-merge Core E2E is pending or failing. If
+`main` moves, the old run is not release evidence: record the new SHA, repeat
+push CI and the complete `main`-mode Core E2E, and tag only that newly qualified
+commit.
 
 ## Tag and GitHub Release
 
@@ -166,7 +197,7 @@ gh variable set DSH_RELEASE_CANARY_SHA --body "$release_sha"
 gh workflow run release-canary.yml --ref main
 ```
 
-Wait for the run and record its URL and conclusion. A successful PR candidate run or `main` CI does not replace this formal-tag smoke.
+Wait for the run and record its URL and conclusion. Pre-merge Core E2E, post-merge Core E2E, and `main` CI do not replace this formal-tag smoke; conversely, the one-task post-release smoke does not replace full post-merge Core E2E before tagging.
 
 If the smoke fails after publication, keep the tag immutable. Diagnose the failure, prepare the next patch release from `main`, and repeat the complete latest-SHA qualification flow.
 

--- a/test/action-metadata.test.ts
+++ b/test/action-metadata.test.ts
@@ -292,8 +292,10 @@ describe("Marketplace action metadata", () => {
     expect(workflow).not.toMatch(/^ {2}pull_request:\s*$/mu);
     expect(gate).toContain("WORKFLOW_REF: ${{ github.ref }}");
     expect(gate).toContain("DISPATCH_SHA: ${{ github.sha }}");
-    expect(gate).toContain("APPROVED_PR_SHA: ${{ vars.DSH_E2E_CANDIDATE_SHA }}");
+    expect(gate).toContain("APPROVED_CANDIDATE_SHA: ${{ vars.DSH_E2E_CANDIDATE_SHA }}");
     expect(gate).toContain('"$DISPATCH_SHA" == "$default_sha"');
+    expect(gate).toContain("candidate_mode:");
+    expect(gate).toContain('"$CANDIDATE_SHA" == "$DISPATCH_SHA"');
     expect(gate).not.toContain("secrets.");
     expect(workflow.match(/environment: core-e2e/gu)).toHaveLength(3);
     expect(workflow.match(/ref: \$\{\{ needs\.gate\.outputs\.harness_sha \}\}/gu)).toHaveLength(4);
@@ -308,6 +310,10 @@ describe("Marketplace action metadata", () => {
     expect(workflow).toContain("bodyMarker:");
     expect(workflow).toContain("dsh-e2e:github-integration:v1");
     expect(workflow).toContain("github.comment.create");
+    expect(workflow).toContain("github.issue.labels.set");
+    expect(workflow).toContain("github.issue.assignees.set");
+    expect(workflow).toContain("github.issue.state.update");
+    expect(workflow).toContain("github.pull.metadata.update");
     expect(workflow).toContain("github.checks.read");
     expect(workflow).toContain("[image removed]");
     expect(workflow).toContain("if: always() && needs.gate.result == 'success'");

--- a/test/e2e-workflow.test.ts
+++ b/test/e2e-workflow.test.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 
 import { beforeAll, describe, expect, it } from "vitest";
+import { parse } from "yaml";
 
 function stepBlock(workflow: string, name: string): string {
   const marker = `      - name: ${name}`;
@@ -15,6 +16,27 @@ describe("trusted core E2E workflow", () => {
 
   beforeAll(async () => {
     workflow = await readFile(new URL("../.github/workflows/e2e.yml", import.meta.url), "utf8");
+  });
+
+  it("parses as YAML and exposes separate pull-request and exact-main qualification modes", () => {
+    expect(() => {
+      parse(workflow);
+    }).not.toThrow();
+    const gate = workflow.slice(0, workflow.indexOf("  read_only:"));
+
+    for (const contract of [
+      "candidate_mode:",
+      "- pull-request",
+      "- main",
+      "APPROVED_CANDIDATE_SHA: ${{ vars.DSH_E2E_CANDIDATE_SHA }}",
+      '[[ "$CANDIDATE_SHA" == "$DISPATCH_SHA" && "$CANDIDATE_SHA" == "$default_sha" ]]',
+      'candidate_branch="$DEFAULT_BRANCH"',
+    ]) {
+      expect(gate).toContain(contract);
+    }
+    expect(gate).toContain('echo "pull_request=$CANDIDATE_PR" >> "$GITHUB_OUTPUT"');
+    expect(workflow).toContain("bash .github/e2e/assert-candidate-binding.sh");
+    expect(workflow).toContain('if [[ "$CANDIDATE_MODE" == "pull-request" ]]; then');
   });
 
   it("keeps the integrity golden path on one minimal trusted-write turn", () => {
@@ -76,30 +98,117 @@ describe("trusted core E2E workflow", () => {
       "INPUT_ASSIGNEE-TRIGGER=dsh-e2e-assignee",
       "INPUT_ALLOWED-ACTORS=dsh-e2e-no-match",
       "INPUT_TRIGGER-PHRASE=/deepseek",
-      "INPUT_EXCLUDE-COMMENTS-BY-ACTOR=github-actions[bot]",
-      'INPUT_ALLOWED-TOOLS=["workspace.edit","github.comment.create"]',
+      "INPUT_EXCLUDE-COMMENTS-BY-ACTOR=$actor,github-actions[bot]",
+      "github.issue.labels.set",
+      "github.issue.assignees.set",
+      "github.issue.state.update",
+      "github.comment.create",
+      "github.pull.metadata.update",
       'INPUT_ALLOWED-TOOLS=["github.checks.read"]',
+      "INPUT_PROMPT=Update the bound draft PR metadata exactly as requested.",
       '.validation.status == "passed"',
       '.taskOutput == {route:"github",accepted:true}',
       "DSH_E2E_HISTORY_HIDDEN_",
       "DSH_E2E_TRIGGER_VISIBLE_",
       "[image removed]",
+      "dsh-e2e-reference-must-not-forward",
+      "dsh-e2e-source-must-not-forward",
+      "dsh-e2e-html-must-not-forward",
+      "dsh-e2e-raw-must-not-forward",
     ]) {
       expect(integration).toContain(contract);
     }
     expect(integration).not.toContain("secrets.DEEPSEEK_API_KEY");
   });
 
-  it("cleans only the identity-verified integration Issue, draft PR, and ref", () => {
+  it("creates an exact one-file fixture commit for main-safe checks coverage", () => {
+    const creation = stepBlock(workflow, "Create isolated Issue and draft PR fixtures");
+
+    for (const contract of [
+      ".github/dsh-e2e-fixtures/checks-",
+      'git/commits/$CANDIDATE_SHA" --jq .tree.sha',
+      "base_tree:$base",
+      "parents:[$parent]",
+      'echo "tree_sha=$tree_sha"',
+      'echo "head_sha=$head_sha"',
+      '--arg sha "$head_sha"',
+    ]) {
+      expect(creation).toContain(contract);
+    }
+    expect(creation).not.toContain('-f sha="$CANDIDATE_SHA" >/dev/null');
+  });
+
+  it("asserts generic receipts and verifies typed payload effects through remote state", () => {
+    const integration = stepBlock(
+      workflow,
+      "Exercise routes, filters, structured output, and typed GitHub tools",
+    );
+
+    expect(integration).toContain('.id == "github.issue.labels.set"');
+    expect(integration).toContain('.id == "github.issue.assignees.set"');
+    expect(integration).toContain('.id == "github.issue.state.update"');
+    expect(integration).toContain('.id == "github.pull.metadata.update"');
+    expect(integration).toContain('.id == "github.checks.read"');
+    expect(integration).toContain("[.labels[].name] == [$label]");
+    expect(integration).toContain("[.assignees[].login] == [$actor]");
+    expect(integration).toContain('.state_reason == "completed"');
+    expect(integration).toContain('--jq .head.sha)" == "$CHECKS_HEAD"');
+    for (const forbiddenReceiptPayload of [
+      ".labels == [$label]",
+      ".assignees == [$actor]",
+      ".title == $title",
+      ".headSha == $head",
+    ]) {
+      expect(integration).not.toContain(forbiddenReceiptPayload);
+    }
+  });
+
+  it("cleans partial integration fixtures independently and aggregates failures", () => {
     const cleanup = stepBlock(workflow, "Remove only verified integration fixtures");
 
     expect(cleanup).toContain("if: always()");
     expect(cleanup).toContain("dsh-e2e:github-integration:v1");
     expect(cleanup).toContain("^dsh-e2e/checks-");
-    expect(cleanup).toContain("(.head.repo.full_name | ascii_downcase) == $repo");
+    expect(cleanup).toContain("cleanup_issue() (");
+    expect(cleanup).toContain("cleanup_label() (");
+    expect(cleanup).toContain("cleanup_pull() (");
+    expect(cleanup).toContain("cleanup_branch() (");
+    expect(cleanup).toContain("cleanup_failures=$((cleanup_failures + 1))");
+    expect(cleanup).toContain('[[ "$cleanup_failures" -eq 0 ]]');
+    expect(cleanup).toContain(".parents[0].sha");
+    expect(cleanup).toContain(".tree.sha");
+    expect(cleanup).toContain(".files | length == 1");
     expect(cleanup).toContain(
       'gh api --method DELETE "repos/$REPOSITORY/git/refs/heads/$CHECKS_BRANCH"',
     );
     expect(cleanup).not.toContain("matching-refs");
+  });
+
+  it("keeps the reusable candidate assertion fail-closed in both modes", async () => {
+    const assertion = await readFile(
+      new URL("../.github/e2e/assert-candidate-binding.sh", import.meta.url),
+      "utf8",
+    );
+
+    expect(assertion).toContain("pull-request)");
+    expect(assertion).toContain('.state == "open" and .draft == false');
+    expect(assertion).toContain("main)");
+    expect(assertion).toContain('live_sha="$(gh api');
+    expect(assertion).toContain('"$live_sha" == "$CANDIDATE_SHA"');
+    expect(assertion).not.toContain("matching-refs");
+  });
+
+  it("requires complete post-merge Core E2E on the exact release SHA before tagging", async () => {
+    const guide = await readFile(new URL("../docs/maintainer-release.md", import.meta.url), "utf8");
+    const merge = guide.slice(
+      guide.indexOf("## Merge and qualify `main`"),
+      guide.indexOf("## Tag and GitHub Release"),
+    );
+
+    expect(merge).toContain('gh variable set DSH_E2E_CANDIDATE_SHA --body "$release_sha"');
+    expect(merge).toContain("-f candidate_mode=main");
+    expect(merge).toContain('-f candidate_sha="$release_sha"');
+    expect(merge).toContain("Wait for every Core E2E job");
+    expect(merge.indexOf("candidate_mode=main")).toBeLessThan(merge.indexOf("Do not tag"));
   });
 });


### PR DESCRIPTION
## Summary
- add separate pull-request and exact-live-main Core E2E qualification modes
- exercise all six Controller-owned typed GitHub operations with remote-state assertions and restoration
- make run-bound label/Issue/draft-PR/ref cleanup partial-creation-safe and identity-verified
- prove inline/reference/HTML/raw GitHub attachment sources stay out of the model prompt
- require full post-merge Core E2E on the exact release SHA before tagging

## Security
- both modes still start from the secretless live-main gate and exact repository variable
- main mode requires candidate, workflow, dispatch, and live default-branch SHAs to match
- the main-safe PR fixture is a one-file commit on an isolated ref; main is never mutated
- cleanup is exact and aggregated; no matching-ref or broad deletion is used

## Validation
- format, lint, typecheck, coverage, release contract, and DSH audit pass
- 579 passed / 2 skipped on current main harness
- workflow YAML and all embedded Bash blocks parse; focused workflow tests pass