### PR TITLE
test: bound integration materialization budget

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1395,7 +1395,7 @@ jobs:
 
           run_candidate label issues "$RUNNER_TEMP/dsh-e2e-label-event.json" label \
             'INPUT_COMMAND=auto' 'INPUT_LABEL-TRIGGER=dsh-e2e-label' \
-            "INPUT_ALLOWED-ACTORS=$actor" 'INPUT_TASK-ACCESS=read' \
+            "INPUT_ALLOWED-ACTORS=$actor" 'INPUT_TASK-ACCESS=read' 'INPUT_ISOLATION=none' \
             'INPUT_PROMPT=Return the deterministic label task result.' \
             "INPUT_TASK-OUTPUT-SCHEMA=$task_schema" 'INPUT_MAX-TURNS=1'
           label_result="$(read_output label result-json)"
@@ -1406,7 +1406,7 @@ jobs:
 
           run_candidate assignee issues "$RUNNER_TEMP/dsh-e2e-assignee-event.json" assignee \
             'INPUT_COMMAND=auto' 'INPUT_ASSIGNEE-TRIGGER=dsh-e2e-assignee' \
-            "INPUT_ALLOWED-ACTORS=$actor" 'INPUT_TASK-ACCESS=read' \
+            "INPUT_ALLOWED-ACTORS=$actor" 'INPUT_TASK-ACCESS=read' 'INPUT_ISOLATION=none' \
             'INPUT_PROMPT=Return the deterministic assignee task result.' \
             "INPUT_TASK-OUTPUT-SCHEMA=$task_schema" 'INPUT_MAX-TURNS=1'
           assignee_result="$(read_output assignee result-json)"
@@ -1514,7 +1514,7 @@ jobs:
 
           run_candidate checks pull_request "$RUNNER_TEMP/dsh-e2e-checks-event.json" checks \
             'INPUT_COMMAND=diagnose' 'INPUT_PERMISSION-PROFILE=custom' \
-            'INPUT_ALLOWED-TOOLS=["github.checks.read"]' 'INPUT_MAX-TURNS=2'
+            'INPUT_ALLOWED-TOOLS=["github.checks.read"]' 'INPUT_ISOLATION=none' 'INPUT_MAX-TURNS=2'
           checks_result="$(read_output checks result-json)"
           jq -c '{stage:"checks",conclusion,status,operation,trust:.policy.trust,toolReceipts:.loop.toolReceipts}' <<<"$checks_result"
           jq -e '

--- a/test/e2e-workflow.test.ts
+++ b/test/e2e-workflow.test.ts
@@ -118,6 +118,7 @@ describe("trusted core E2E workflow", () => {
     ]) {
       expect(integration).toContain(contract);
     }
+    expect(integration.match(/'INPUT_ISOLATION=none'/gu)).toHaveLength(3);
     expect(integration).not.toContain("secrets.DEEPSEEK_API_KEY");
   });
 


### PR DESCRIPTION
Runs label, assignee, and checks read contracts without Docker repository materialization. Core read/write jobs still cover Docker isolation; the two integration write routes still materialize, validate, reconcile, and mutate real fixtures.