### PR TITLE
test: install exact host runtime for read contracts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1166,6 +1166,9 @@ jobs:
         with:
           node-version: 24
 
+      - name: Install exact candidate runtime without lifecycle scripts
+        run: npm ci --prefix candidate-action --omit=dev --ignore-scripts --no-audit --no-fund
+
       - name: Prepare deterministic GitHub integration harness
         id: integration_baseline
         shell: bash

--- a/test/e2e-workflow.test.ts
+++ b/test/e2e-workflow.test.ts
@@ -88,9 +88,17 @@ describe("trusted core E2E workflow", () => {
   });
 
   it("exercises v0.6 GitHub integration through deterministic exact-DSH runs", () => {
+    const install = stepBlock(
+      workflow,
+      "Install exact candidate runtime without lifecycle scripts",
+    );
     const integration = stepBlock(
       workflow,
       "Exercise routes, filters, structured output, and typed GitHub tools",
+    );
+
+    expect(install).toContain(
+      "npm ci --prefix candidate-action --omit=dev --ignore-scripts --no-audit --no-fund",
     );
 
     for (const contract of [


### PR DESCRIPTION
Installs the candidate's exact locked production dependencies once, with lifecycle scripts disabled, so label/assignee/checks read contracts can use host isolation without repeated GitHub repository materialization.