### PR TITLE
release: publish installer 0.1.1 for v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 Notable user-facing changes are recorded here. This project follows semantic
 versioning for published action releases.
 
+## Installer 0.1.1 - 2026-08-24
+
+- Updated the standalone `create-deepseek-harness-action` package so its
+  controlled pack step binds both generated workflows to the immutable v0.6.0
+  release commit. The npm package remains versioned independently from the
+  Action.
+- Preserved credential-free checkout, trusted-base fork review, minimum token
+  permissions, Docker isolation, explicit write opt-in, fail-closed validation,
+  strict Validation Integrity, and overwrite refusal. No Action runtime or
+  v0.6.0 tag content changed.
+
 ## [0.6.0] - 2026-08-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ For CI or another non-interactive environment, pass the mode explicitly so the i
 npm create deepseek-harness-action@latest -- --mode both
 ```
 
-The installer creates `.github/workflows/` when needed and refuses to overwrite an existing target workflow. It does not add secrets, commit or push changes, or open a pull request. The generated workflows pin the Action to the immutable v0.5.2 release commit.
+The installer creates `.github/workflows/` when needed and refuses to overwrite an existing target workflow. It does not add secrets, commit or push changes, or open a pull request. Installer v0.1.1 generates workflows pinned to the immutable v0.6.0 release commit.
 
 After installation, add `DEEPSEEK_API_KEY` under **Settings → Secrets and variables → Actions**. Open or update a non-draft pull request to trigger Review. For Coding Commands, put an `@dsh` command on the first line of an Issue or pull request comment. See [Setup](docs/setup.md) for the complete onboarding and security guide.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -58,7 +58,7 @@ npm create deepseek-harness-action@latest
 npm create deepseek-harness-action@latest -- --mode both
 ```
 
-安装器会按需创建 `.github/workflows/`，如果目标 workflow 已存在则拒绝覆盖。它不会添加 Secret、commit 或 push 改动，也不会创建 PR。生成的 workflow 会把 Action 固定到 v0.5.2 的不可变 release commit。
+安装器会按需创建 `.github/workflows/`，如果目标 workflow 已存在则拒绝覆盖。它不会添加 Secret、commit 或 push 改动，也不会创建 PR。安装器 v0.1.1 生成的 workflow 会把 Action 固定到 v0.6.0 的不可变 release commit。
 
 安装完成后，在 **Settings → Secrets and variables → Actions** 中添加 `DEEPSEEK_API_KEY`。打开或更新一个非 draft PR 即可触发 Review；使用 Coding Commands 时，把 `@dsh` 命令写在 Issue 或 PR 评论的第一行。完整 onboarding 与安全说明见[安装指南](docs/setup.zh-CN.md)。
 

--- a/docs/maintainer-release.md
+++ b/docs/maintainer-release.md
@@ -60,7 +60,7 @@ For an Action version bump, update every release surface together:
 6. Any release-specific verification fixture or documentation.
 
 The standalone `create-deepseek-harness-action` package has its own semantic
-version. For v0.5.2 its version is `0.1.0`; do not change it to the Action
+version. Its v0.6.0 companion release is `0.1.1`; do not change it to the Action
 version. Keep its package manifest, npm lock/workspace metadata, CLI tests, and
 pack-time release-SHA contract aligned.
 
@@ -203,22 +203,28 @@ If the smoke fails after publication, keep the tag immutable. Diagnose the failu
 
 ## Publish the npm create package
 
-Publish `create-deepseek-harness-action` only after the formal tag, GitHub
-Release, and release canary all resolve to `release_sha`. A Git commit cannot
-safely contain its own not-yet-known object ID, so the source package uses one
-controlled build token. The npm tarball is built in a disposable checkout of
-the exact tagged commit and injects the real SHA at pack time. Never commit a
-guessed candidate SHA, move the release tag, or publish a tarball containing the
-token or a floating Action tag.
+Publish `create-deepseek-harness-action` only after the formal Action tag,
+GitHub Release, and release canary all resolve to `release_sha`. A Git commit
+cannot safely contain its own not-yet-known object ID, so the source package
+uses one controlled build token. When an installer patch follows the Action
+release, keep two identities: `release_sha` is the immutable Action commit
+written into generated workflows, while `installer_source_sha` is the reviewed
+commit containing the installer manifest, tests, and documentation. Create an
+immutable `create-deepseek-harness-action-vX.Y.Z` source tag after CI succeeds
+on that exact installer commit. Never move either tag or publish a tarball from
+an unreviewed working tree, with an unresolved token, or with a floating Action
+reference.
 
-First verify the published release identity again and create a detached staging
-checkout. The tag-resolution loop accepts either an annotated or lightweight
-tag and must end at the already qualified commit:
+First verify the published Action release identity and the installer source tag,
+then create a detached staging checkout. Each tag-resolution loop accepts an
+annotated or lightweight tag and must end at its expected commit:
 
 ```bash
 release_tag="vX.Y.Z"
+installer_tag="create-deepseek-harness-action-v0.1.1"
 sha_pattern='^[0-9a-f]{40}$'
 [[ "$release_sha" =~ $sha_pattern ]]
+[[ "$installer_source_sha" =~ $sha_pattern ]]
 
 release_json="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$release_tag")"
 jq -e --arg tag "$release_tag" '
@@ -236,8 +242,19 @@ for _ in 1 2 3 4 5; do
 done
 [[ "$object_type" == "commit" && "$object_sha" == "$release_sha" ]]
 
+installer_ref_json="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$installer_tag")"
+installer_object_sha="$(jq -r '.object.sha' <<<"$installer_ref_json")"
+installer_object_type="$(jq -r '.object.type' <<<"$installer_ref_json")"
+for _ in 1 2 3 4 5; do
+  [[ "$installer_object_type" != "tag" ]] && break
+  installer_tag_json="$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$installer_object_sha")"
+  installer_object_sha="$(jq -r '.object.sha' <<<"$installer_tag_json")"
+  installer_object_type="$(jq -r '.object.type' <<<"$installer_tag_json")"
+done
+[[ "$installer_object_type" == "commit" && "$installer_object_sha" == "$installer_source_sha" ]]
+
 installer_stage="$(mktemp -d)"
-git worktree add --detach "$installer_stage/source" "$release_sha"
+git worktree add --detach "$installer_stage/source" "$installer_source_sha"
 mkdir "$installer_stage/pack" "$installer_stage/unpacked" "$installer_stage/smoke"
 ```
 
@@ -257,8 +274,8 @@ tar -xzf "$tarball" -C "$installer_stage/unpacked"
 ```
 
 Inspect the packed artifact, not only the source tree. It must contain version
-`0.1.0`, expose the `create-deepseek-harness-action` executable, contain no
-unresolved release token or floating `v0.5.2` Action reference, and generate
+`0.1.1`, expose the `create-deepseek-harness-action` executable, contain no
+unresolved release token or floating `v0.6.0` Action reference, and generate
 exactly two workflows bound to `release_sha` in a non-interactive smoke run:
 
 ```bash
@@ -268,11 +285,11 @@ import { readFile } from "node:fs/promises";
 
 const manifest = JSON.parse(await readFile(process.argv[2], "utf8"));
 assert.equal(manifest.name, "create-deepseek-harness-action");
-assert.equal(manifest.version, "0.1.0");
+assert.equal(manifest.version, "0.1.1");
 assert.ok(manifest.bin?.["create-deepseek-harness-action"]);
 NODE
 
-! grep -R -E '__[A-Z0-9_]*RELEASE[A-Z0-9_]*__|deepseek-harness-action@v0\.5\.2' \
+! grep -R -E '__[A-Z0-9_]*RELEASE[A-Z0-9_]*__|Lixiaoyiao/deepseek-harness-action@(v[0-9]|main|latest)' \
   "$installer_stage/unpacked/package"
 
 (
@@ -284,7 +301,7 @@ NODE
 test "$(find "$installer_stage/smoke/.github/workflows" -type f -name '*.yml' | wc -l)" -eq 2
 while IFS= read -r workflow; do
   grep -F "uses: Lixiaoyiao/deepseek-harness-action@$release_sha" "$workflow"
-  ! grep -E 'deepseek-harness-action@(v0\.5\.2|main|latest)' "$workflow"
+  ! grep -E 'Lixiaoyiao/deepseek-harness-action@(v[0-9]|main|latest)' "$workflow"
 done < <(find "$installer_stage/smoke/.github/workflows" -type f -name '*.yml')
 ```
 
@@ -295,7 +312,7 @@ that would rerun packing with an unreviewed environment:
 ```bash
 npm whoami --registry=https://registry.npmjs.org/
 npm publish "$tarball" --access public --registry=https://registry.npmjs.org/
-npm view create-deepseek-harness-action@0.1.0 \
+npm view create-deepseek-harness-action@0.1.1 \
   name version dist-tags --json --registry=https://registry.npmjs.org/
 ```
 
@@ -305,4 +322,4 @@ generated workflow files still contain only `release_sha`, parse as YAML, and
 retain the required checkout, permission, Docker, validation, and credential
 boundaries. Then remove the disposable worktree and staging directory. npm
 versions and the release tag are immutable; a bad published installer must be
-fixed with a new installer patch version rather than replacing `0.1.0`.
+fixed with a new installer patch version rather than replacing `0.1.1`.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -26,7 +26,7 @@ For CI or another non-interactive environment, pass the mode explicitly. The ins
 npm create deepseek-harness-action@latest -- --mode both
 ```
 
-The installer creates `.github/workflows/` when necessary and refuses to overwrite an existing target workflow. It does not add `DEEPSEEK_API_KEY`, commit or push changes, or open a pull request. The generated workflows pin the Action to the immutable v0.5.2 release commit.
+The installer creates `.github/workflows/` when necessary and refuses to overwrite an existing target workflow. It does not add `DEEPSEEK_API_KEY`, commit or push changes, or open a pull request. Installer v0.1.1 generates workflows pinned to the immutable v0.6.0 release commit.
 
 After the installer succeeds:
 

--- a/docs/setup.zh-CN.md
+++ b/docs/setup.zh-CN.md
@@ -26,7 +26,7 @@ npm create deepseek-harness-action@latest
 npm create deepseek-harness-action@latest -- --mode both
 ```
 
-安装器会按需创建 `.github/workflows/`，如果目标 workflow 已存在则拒绝覆盖。它不会添加 `DEEPSEEK_API_KEY`、commit 或 push 改动，也不会创建 PR。生成的 workflow 会把 Action 固定到 v0.5.2 的不可变 release commit。
+安装器会按需创建 `.github/workflows/`，如果目标 workflow 已存在则拒绝覆盖。它不会添加 `DEEPSEEK_API_KEY`、commit 或 push 改动，也不会创建 PR。安装器 v0.1.1 生成的 workflow 会把 Action 固定到 v0.6.0 的不可变 release commit。
 
 安装成功后：
 

--- a/packages/create-deepseek-harness-action/README.md
+++ b/packages/create-deepseek-harness-action/README.md
@@ -17,3 +17,7 @@ npm create deepseek-harness-action@latest -- --mode both
 Valid modes are `review`, `commands`, and `both`. The installer creates only
 workflow files. It does not add secrets, commit, push, or open a pull request.
 Existing workflow files are never overwritten.
+
+Version `0.1.1` is built only after the formal Action release exists. Its
+generated workflows pin the immutable v0.6.0 release commit, not a floating
+tag or branch.

--- a/packages/create-deepseek-harness-action/package-lock.json
+++ b/packages/create-deepseek-harness-action/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-deepseek-harness-action",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-deepseek-harness-action",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "bin": {
         "create-deepseek-harness-action": "dist/cli.mjs"

--- a/packages/create-deepseek-harness-action/package.json
+++ b/packages/create-deepseek-harness-action/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-deepseek-harness-action",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Create safe DeepSeek Harness GitHub workflows",
   "private": false,
   "type": "module",

--- a/packages/create-deepseek-harness-action/src/installer.mjs
+++ b/packages/create-deepseek-harness-action/src/installer.mjs
@@ -5,7 +5,7 @@ import { join, resolve } from "node:path";
 import { createInterface } from "node:readline/promises";
 
 const DOCUMENTATION_URL =
-  "https://github.com/Lixiaoyiao/deepseek-harness-action/blob/v0.5.2/docs/setup.md";
+  "https://github.com/Lixiaoyiao/deepseek-harness-action/blob/v0.6.0/docs/setup.md";
 const ACTION_REFERENCE_PATTERN = /uses: Lixiaoyiao\/deepseek-harness-action@[0-9a-f]{40}(?:\s|$)/gu;
 const MODES = new Set(["review", "commands", "both"]);
 const WORKFLOWS = Object.freeze({

--- a/scripts/verify-release-contract.mjs
+++ b/scripts/verify-release-contract.mjs
@@ -22,6 +22,7 @@ const [
   installerManifestText,
   installerLockText,
   installerBuild,
+  installerRuntime,
   installerReview,
   installerCommands,
 ] = await Promise.all([
@@ -33,6 +34,7 @@ const [
   read("packages/create-deepseek-harness-action/package.json"),
   read("packages/create-deepseek-harness-action/package-lock.json"),
   read("packages/create-deepseek-harness-action/scripts/build.mjs"),
+  read("packages/create-deepseek-harness-action/src/installer.mjs"),
   read("packages/create-deepseek-harness-action/src/templates/dsh-review.yml"),
   read("packages/create-deepseek-harness-action/src/templates/dsh-commands.yml"),
 ]);
@@ -40,6 +42,7 @@ const manifest = JSON.parse(manifestText);
 const lock = JSON.parse(lockText);
 const installerManifest = JSON.parse(installerManifestText);
 const installerLock = JSON.parse(installerLockText);
+const installerVersion = "0.1.1";
 const directDependencies = {
   ...(manifest.dependencies ?? {}),
   ...(manifest.devDependencies ?? {}),
@@ -124,7 +127,7 @@ assert.equal(
   "create-deepseek-harness-action",
   "installer npm package name drifted",
 );
-assert.equal(installerManifest.version, "0.1.0", "installer version must start at 0.1.0");
+assert.equal(installerManifest.version, installerVersion, "installer version drifted");
 assert.equal(installerManifest.private, false, "installer must remain publishable");
 assert.equal(
   installerManifest.bin?.["create-deepseek-harness-action"],
@@ -142,8 +145,16 @@ assert.deepEqual(
   { access: "public", registry: "https://registry.npmjs.org/" },
   "installer must publish publicly through the official npm registry",
 );
-assert.equal(installerLock.version, "0.1.0", "installer lock version drifted");
-assert.equal(installerLock.packages?.[""]?.version, "0.1.0", "installer root lock version drifted");
+assert.equal(installerLock.version, installerVersion, "installer lock version drifted");
+assert.equal(
+  installerLock.packages?.[""]?.version,
+  installerVersion,
+  "installer root lock version drifted",
+);
+assert.ok(
+  installerRuntime.includes("/blob/v0.6.0/docs/setup.md"),
+  "installer documentation must bind to the v0.6.0 release",
+);
 
 const installerReleaseToken = "__DSH_ACTION_RELEASE_SHA__";
 assert.ok(

--- a/test/installer.test.ts
+++ b/test/installer.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../packages/create-deepseek-harness-action/src/installer.mjs";
 
 const execFileAsync = promisify(execFile);
+const INSTALLER_VERSION = "0.1.1";
 const RELEASE_SHA = "1234567890abcdef1234567890abcdef12345678";
 const RELEASE_TOKEN = "__DSH_ACTION_RELEASE_SHA__";
 const packageRoot = new URL("../packages/create-deepseek-harness-action/", import.meta.url);
@@ -82,13 +83,13 @@ afterAll(async () => {
 });
 
 describe("create-deepseek-harness-action release build", () => {
-  it("declares the independent 0.1.0 npm create package", async () => {
+  it("declares the independent 0.1.1 npm create package", async () => {
     const manifest: unknown = JSON.parse(
       await readFile(new URL("package.json", packageRoot), "utf8"),
     );
     expect(manifest).toMatchObject({
       name: "create-deepseek-harness-action",
-      version: "0.1.0",
+      version: INSTALLER_VERSION,
       private: false,
       type: "module",
       bin: { "create-deepseek-harness-action": "./dist/cli.mjs" },
@@ -115,16 +116,28 @@ describe("create-deepseek-harness-action release build", () => {
         RELEASE_TOKEN,
       );
     }
+    await expect(readFile(join(builtPackage, "installer.mjs"), "utf8")).resolves.toContain(
+      "/blob/v0.6.0/docs/setup.md",
+    );
 
-    const invalidOutput = join(suiteDirectory, "invalid-build");
-    const environment = { ...process.env };
-    delete environment.DSH_ACTION_RELEASE_SHA;
-    await expect(
-      execFileAsync(process.execPath, [buildScript, "--output", invalidOutput], {
-        env: environment,
-        windowsHide: true,
-      }),
-    ).rejects.toThrow(/DSH_ACTION_RELEASE_SHA/u);
+    for (const [index, invalidReleaseSha] of [
+      undefined,
+      "v0.6.0",
+      "1234",
+      "A".repeat(40),
+      "g".repeat(40),
+    ].entries()) {
+      const environment = { ...process.env };
+      if (invalidReleaseSha === undefined) delete environment.DSH_ACTION_RELEASE_SHA;
+      else environment.DSH_ACTION_RELEASE_SHA = invalidReleaseSha;
+      await expect(
+        execFileAsync(
+          process.execPath,
+          [buildScript, "--output", join(suiteDirectory, `invalid-build-${String(index)}`)],
+          { env: environment, windowsHide: true },
+        ),
+      ).rejects.toThrow(/DSH_ACTION_RELEASE_SHA/u);
+    }
 
     for (const unsafeOutput of [packageRootPath, process.cwd(), parsePath(process.cwd()).root]) {
       await expect(
@@ -157,9 +170,9 @@ describe("create-deepseek-harness-action release build", () => {
 
     expect(packResult).toHaveLength(1);
     expect(packResult[0]).toMatchObject({
-      filename: "create-deepseek-harness-action-0.1.0.tgz",
+      filename: `create-deepseek-harness-action-${INSTALLER_VERSION}.tgz`,
       name: "create-deepseek-harness-action",
-      version: "0.1.0",
+      version: INSTALLER_VERSION,
     });
     await expect(
       readFile(join(packDirectory, packResult[0]?.filename ?? "")),
@@ -348,6 +361,20 @@ describe("generated workflow contracts", () => {
     expect(() => {
       parse(commands);
     }).not.toThrow();
+    const reviewDocument = parse(review) as { permissions?: Record<string, string> };
+    const commandsDocument = parse(commands) as { permissions?: Record<string, string> };
+
+    expect(reviewDocument.permissions).toEqual({
+      contents: "read",
+      "pull-requests": "write",
+    });
+    expect(commandsDocument.permissions).toEqual({
+      actions: "read",
+      checks: "read",
+      contents: "write",
+      issues: "write",
+      "pull-requests": "write",
+    });
 
     expect(review).toContain("pull_request_target:");
     expect(review).not.toMatch(/^\s+pull_request:\s*$/mu);
@@ -378,7 +405,9 @@ describe("generated workflow contracts", () => {
     expect(commands).toContain('run-tests: "true"');
     expect(commands).toContain("validation-integrity: strict");
     expect(commands).toContain("process.exit(1)");
-    expect(commands).toContain("container-image: docker.io/library/node:24.18.0-bookworm@sha256:");
+    expect(commands).toMatch(
+      /^\s+container-image: docker\.io\/library\/node:24\.18\.0-bookworm@sha256:[0-9a-f]{64}$/mu,
+    );
 
     for (const contents of [review, commands]) {
       expect(
@@ -386,8 +415,15 @@ describe("generated workflow contracts", () => {
       ).toHaveLength(1);
       expect(contents).not.toContain(RELEASE_TOKEN);
       expect(contents).not.toContain("github-token:");
+      expect(contents).not.toContain("id-token:");
+      expect(contents).not.toContain("secrets: inherit");
+      expect(contents).not.toContain("GITHUB_TOKEN");
+      expect(contents).not.toContain("GH_TOKEN");
       expect(contents).not.toMatch(/^\s+env:\s*$/mu);
       expect(contents).toContain("deepseek-api-key: ${{ secrets.DEEPSEEK_API_KEY }}");
+      expect(
+        contents.match(/uses: actions\/checkout@11d5960a326750d5838078e36cf38b85af677262/gu),
+      ).toHaveLength(1);
     }
   });
 });


### PR DESCRIPTION
## Summary

- bump the standalone installer to 0.1.1
- bind its documentation and controlled pack contract to formal Action v0.6.0
- keep generated workflow permissions, trusted checkout, Docker, validation, and credential boundaries unchanged
- document separate immutable Action and installer-source identities for post-tag installer patches

## Verification

- `npm run check`
- exact v0.6.0 SHA pack and tarball allowlist inspection
- packed `--mode both` smoke with YAML parsing and exact Action SHA assertions

The template source retains the single controlled release placeholder; no real SHA or floating Action ref is committed.