### PR TITLE
release: create-deepseek-harness-action v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 Notable user-facing changes are recorded here. This project follows semantic
 versioning for published action releases.
 
+## Installer 0.2.0 - 2026-08-26
+
+- Added `--dsh-mode controlled|native` to the independently versioned
+  `create-deepseek-harness-action` package. `controlled` remains the default;
+  native composition requires an explicit selection in non-interactive use and
+  a clear choice in the interactive flow. The existing
+  `--mode review|commands|both` workflow selection is unchanged.
+- Bound the production package build to the formal v0.8.0 release commit
+  `86fff4c4527694c7eefdc65c6cf7a633b5ea8cb1` through the existing
+  `DSH_ACTION_RELEASE_SHA` pack contract. Generated workflows never use a
+  candidate SHA, floating tag, or branch.
+- Added deterministic coverage for all six workflow-mode and DSH-mode
+  combinations plus packed-tarball smoke checks for YAML parsing, immutable
+  Action identity, controlled default behavior, native opt-in, release-token
+  removal, credential-free checkout, and overwrite refusal.
+- Preserved the installer's safety boundaries: it creates workflow files only,
+  never writes a secret, commit, push, or pull request, and never overwrites an
+  existing workflow. This installer release does not add an Action-owned GitHub
+  MCP backend or Session/Resume, and the audited DSH version remains
+  `0.1.1-rc.2`.
+
 ## [0.8.0] - 2026-08-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -65,7 +65,20 @@ For CI or another non-interactive environment, pass the mode explicitly so the i
 npm create deepseek-harness-action@latest -- --mode both
 ```
 
-The installer creates `.github/workflows/` when needed and refuses to overwrite an existing target workflow. It does not add secrets, commit or push changes, or open a pull request. Installer v0.1.1 generates workflows pinned to the immutable v0.6.0 release commit.
+For non-interactive use, omitting `--dsh-mode` keeps the compatible `controlled`
+default. The interactive flow asks explicitly; choose Controlled there unless
+native composition is intended:
+
+```bash
+npm create deepseek-harness-action@latest -- --mode both --dsh-mode native
+```
+
+The installer creates `.github/workflows/` when needed and refuses to overwrite
+an existing target workflow. It does not add secrets, commit or push changes,
+or open a pull request. Installer v0.2.0 is built only from the formal v0.8.0
+release identity and generates workflows pinned to immutable commit
+`86fff4c4527694c7eefdc65c6cf7a633b5ea8cb1`, not a candidate SHA, floating tag,
+or branch.
 
 After installation, add `DEEPSEEK_API_KEY` under **Settings → Secrets and variables → Actions**. Open or update a non-draft pull request to trigger Review. For Coding Commands, put an `@dsh` command on the first line of an Issue or pull request comment. See [Setup](docs/setup.md) for the complete onboarding and security guide.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -65,7 +65,18 @@ npm create deepseek-harness-action@latest
 npm create deepseek-harness-action@latest -- --mode both
 ```
 
-安装器会按需创建 `.github/workflows/`，如果目标 workflow 已存在则拒绝覆盖。它不会添加 Secret、commit 或 push 改动，也不会创建 PR。安装器 v0.1.1 生成的 workflow 会把 Action 固定到 v0.6.0 的不可变 release commit。
+非交互使用时，省略 `--dsh-mode` 会保持兼容的 `controlled` 默认值。交互流程
+会明确询问；除非确实需要 native composition，否则请选择 Controlled：
+
+```bash
+npm create deepseek-harness-action@latest -- --mode both --dsh-mode native
+```
+
+安装器会按需创建 `.github/workflows/`，如果目标 workflow 已存在则拒绝覆盖。
+它不会添加 Secret、commit 或 push 改动，也不会创建 PR。安装器 v0.2.0
+只根据正式 v0.8.0 release identity 构建，生成的 workflow 固定到不可变 commit
+`86fff4c4527694c7eefdc65c6cf7a633b5ea8cb1`，不会使用 candidate SHA、浮动 Tag
+或分支。
 
 安装完成后，在 **Settings → Secrets and variables → Actions** 中添加 `DEEPSEEK_API_KEY`。打开或更新一个非 draft PR 即可触发 Review；使用 Coding Commands 时，把 `@dsh` 命令写在 Issue 或 PR 评论的第一行。完整 onboarding 与安全说明见[安装指南](docs/setup.zh-CN.md)。
 

--- a/docs/maintainer-release.md
+++ b/docs/maintainer-release.md
@@ -7,12 +7,11 @@ This guide is for repository maintainers qualifying and publishing an Action rel
 v0.8.0 publishes the experimental `NativeComposition` and official native MCP,
 Profile Bundle, Cordis Plugin, repository Skills, Subagent, and Workflow
 compatibility together with the subsequent behavior-preserving Controller
-cleanup. Freeze and qualify the exact Release PR candidate, merge only after
-required CI and Core E2E pass, then repeat CI, Core E2E, and native ecosystem
-smoke against the exact `main` release SHA before creating the annotated tag and
-GitHub Release. Run the formal tag canary only after those identities agree. The
-standalone installer remains independently versioned at `0.1.1` with its v0.6.0
-Action binding throughout this Action Release PR.
+cleanup. Its formal annotated tag, GitHub Release, and release canary resolve to
+commit `86fff4c4527694c7eefdc65c6cf7a633b5ea8cb1`. The independently versioned
+installer follows as `0.2.0` only after that Action identity is complete. Its
+reviewed source has a separate immutable tag, while its pack step binds generated
+workflows to the formal Action commit through `DSH_ACTION_RELEASE_SHA`.
 
 ## Release invariants
 
@@ -76,9 +75,11 @@ For an Action version bump, update every release surface together:
 6. Any release-specific verification fixture or documentation.
 
 The standalone `create-deepseek-harness-action` package has its own semantic
-version. Its v0.6.0 companion release is `0.1.1`; do not change it to the Action
-version. Keep its package manifest, npm lock/workspace metadata, CLI tests, and
-pack-time release-SHA contract aligned.
+version. Its v0.8.0 companion release is `0.2.0`; do not change it to the Action
+version. Keep its package manifest, npm lock/workspace metadata, CLI tests,
+controlled/native templates, and pack-time release-SHA contract aligned. The
+formal v0.8.0 Action binding is
+`86fff4c4527694c7eefdc65c6cf7a633b5ea8cb1`.
 
 For a DSH version bump, additionally:
 
@@ -246,34 +247,37 @@ then create a detached staging checkout. Each tag-resolution loop accepts an
 annotated or lightweight tag and must end at its expected commit:
 
 ```bash
-release_tag="vX.Y.Z"
-installer_tag="create-deepseek-harness-action-v0.1.1"
+release_tag="v0.8.0"
+release_sha="86fff4c4527694c7eefdc65c6cf7a633b5ea8cb1"
+installer_tag="create-deepseek-harness-action-v0.2.0"
+installer_source_sha="${INSTALLER_SOURCE_SHA:?Set the reviewed installer source commit SHA}"
+repository="Lixiaoyiao/deepseek-harness-action"
 sha_pattern='^[0-9a-f]{40}$'
 [[ "$release_sha" =~ $sha_pattern ]]
 [[ "$installer_source_sha" =~ $sha_pattern ]]
 
-release_json="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$release_tag")"
+release_json="$(gh api "repos/$repository/releases/tags/$release_tag")"
 jq -e --arg tag "$release_tag" '
   .tag_name == $tag and .draft == false and .prerelease == false
 ' <<<"$release_json" >/dev/null
 
-ref_json="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$release_tag")"
+ref_json="$(gh api "repos/$repository/git/ref/tags/$release_tag")"
 object_sha="$(jq -r '.object.sha' <<<"$ref_json")"
 object_type="$(jq -r '.object.type' <<<"$ref_json")"
 for _ in 1 2 3 4 5; do
   [[ "$object_type" != "tag" ]] && break
-  tag_json="$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$object_sha")"
+  tag_json="$(gh api "repos/$repository/git/tags/$object_sha")"
   object_sha="$(jq -r '.object.sha' <<<"$tag_json")"
   object_type="$(jq -r '.object.type' <<<"$tag_json")"
 done
 [[ "$object_type" == "commit" && "$object_sha" == "$release_sha" ]]
 
-installer_ref_json="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$installer_tag")"
+installer_ref_json="$(gh api "repos/$repository/git/ref/tags/$installer_tag")"
 installer_object_sha="$(jq -r '.object.sha' <<<"$installer_ref_json")"
 installer_object_type="$(jq -r '.object.type' <<<"$installer_ref_json")"
 for _ in 1 2 3 4 5; do
   [[ "$installer_object_type" != "tag" ]] && break
-  installer_tag_json="$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$installer_object_sha")"
+  installer_tag_json="$(gh api "repos/$repository/git/tags/$installer_object_sha")"
   installer_object_sha="$(jq -r '.object.sha' <<<"$installer_tag_json")"
   installer_object_type="$(jq -r '.object.type' <<<"$installer_tag_json")"
 done
@@ -281,7 +285,8 @@ done
 
 installer_stage="$(mktemp -d)"
 git worktree add --detach "$installer_stage/source" "$installer_source_sha"
-mkdir "$installer_stage/pack" "$installer_stage/unpacked" "$installer_stage/smoke"
+mkdir "$installer_stage/pack" "$installer_stage/unpacked" \
+  "$installer_stage/controlled" "$installer_stage/native" "$installer_stage/overwrite"
 ```
 
 Pack with the verified SHA as the only production substitution input. The
@@ -300,9 +305,9 @@ tar -xzf "$tarball" -C "$installer_stage/unpacked"
 ```
 
 Inspect the packed artifact, not only the source tree. It must contain version
-`0.1.1`, expose the `create-deepseek-harness-action` executable, contain no
-unresolved release token or floating `v0.6.0` Action reference, and generate
-exactly two workflows bound to `release_sha` in a non-interactive smoke run:
+`0.2.0`, expose the `create-deepseek-harness-action` executable, contain no
+unresolved release token or floating Action reference, and generate controlled
+and native workflows bound only to `release_sha`:
 
 ```bash
 node --input-type=module - "$installer_stage/unpacked/package/package.json" <<'NODE'
@@ -311,7 +316,7 @@ import { readFile } from "node:fs/promises";
 
 const manifest = JSON.parse(await readFile(process.argv[2], "utf8"));
 assert.equal(manifest.name, "create-deepseek-harness-action");
-assert.equal(manifest.version, "0.1.1");
+assert.equal(manifest.version, "0.2.0");
 assert.ok(manifest.bin?.["create-deepseek-harness-action"]);
 NODE
 
@@ -319,17 +324,50 @@ NODE
   "$installer_stage/unpacked/package"
 
 (
-  cd "$installer_stage/smoke"
+  cd "$installer_stage/controlled"
   npm exec --yes --package "$tarball" -- \
     create-deepseek-harness-action --mode both
 )
 
-test "$(find "$installer_stage/smoke/.github/workflows" -type f -name '*.yml' | wc -l)" -eq 2
-while IFS= read -r workflow; do
-  grep -F "uses: Lixiaoyiao/deepseek-harness-action@$release_sha" "$workflow"
-  ! grep -E 'Lixiaoyiao/deepseek-harness-action@(v[0-9]|main|latest)' "$workflow"
-done < <(find "$installer_stage/smoke/.github/workflows" -type f -name '*.yml')
+(
+  cd "$installer_stage/native"
+  npm exec --yes --package "$tarball" -- \
+    create-deepseek-harness-action --mode both --dsh-mode native
+)
+
+for variant in controlled native; do
+  workflow_root="$installer_stage/$variant/.github/workflows"
+  test "$(find "$workflow_root" -type f -name '*.yml' | wc -l)" -eq 2
+  while IFS= read -r workflow; do
+    test "$(grep -F -o "Lixiaoyiao/deepseek-harness-action@$release_sha" "$workflow" | wc -l)" -eq 1
+    grep -F "persist-credentials: false" "$workflow" >/dev/null
+    ! grep -E 'Lixiaoyiao/deepseek-harness-action@(v[0-9]|main|latest)' "$workflow"
+  done < <(find "$workflow_root" -type f -name '*.yml')
+done
+
+! grep -R -E '^\s+dsh-mode:\s+native\s*$' "$installer_stage/controlled/.github/workflows"
+test "$(grep -R -l -E '^\s+dsh-mode:\s+native\s*$' "$installer_stage/native/.github/workflows" | wc -l)" -eq 2
+
+mkdir -p "$installer_stage/overwrite/.github/workflows"
+printf 'user-owned\n' >"$installer_stage/overwrite/.github/workflows/dsh-review.yml"
+if (
+  cd "$installer_stage/overwrite"
+  npm exec --yes --package "$tarball" -- \
+    create-deepseek-harness-action --mode both --dsh-mode native
+); then
+  echo "installer unexpectedly overwrote an existing workflow" >&2
+  exit 1
+fi
+test "$(cat "$installer_stage/overwrite/.github/workflows/dsh-review.yml")" = "user-owned"
+test ! -e "$installer_stage/overwrite/.github/workflows/dsh-commands.yml"
 ```
+
+Parse all four generated workflow files as YAML using the already-installed
+repository `yaml` dependency. Confirm the controlled pair resolves the default
+composition, the native pair explicitly selects `dsh-mode: native`, and every
+file contains exactly one immutable Action reference. The deterministic test
+suite separately covers all six `review|commands|both` × `controlled|native`
+combinations.
 
 Only after those checks pass, authenticate to the official npm registry and
 publish that exact tarball. Do not publish from the source directory because
@@ -338,14 +376,39 @@ that would rerun packing with an unreviewed environment:
 ```bash
 npm whoami --registry=https://registry.npmjs.org/
 npm publish "$tarball" --access public --registry=https://registry.npmjs.org/
-npm view create-deepseek-harness-action@0.1.1 \
+npm view create-deepseek-harness-action@0.2.0 \
   name version dist-tags --json --registry=https://registry.npmjs.org/
 ```
 
-Run one final `npm create deepseek-harness-action@latest -- --mode both` smoke
-from an empty temporary directory against the public registry. Confirm the two
-generated workflow files still contain only `release_sha`, parse as YAML, and
-retain the required checkout, permission, Docker, validation, and credential
-boundaries. Then remove the disposable worktree and staging directory. npm
-versions and the release tag are immutable; a bad published installer must be
-fixed with a new installer patch version rather than replacing `0.1.1`.
+Stop if `npm whoami` fails; the configured default registry may be a mirror, so
+every authentication, publish, view, and public consumer command must name the
+official registry explicitly. After publication, create three new empty
+directories and run representative consumers from the official package:
+
+```bash
+mkdir "$installer_stage/public-review" \
+  "$installer_stage/public-commands-native" "$installer_stage/public-both"
+(
+  cd "$installer_stage/public-review"
+  npm_config_registry=https://registry.npmjs.org/ \
+    npm create deepseek-harness-action@0.2.0 -- --mode review
+)
+(
+  cd "$installer_stage/public-commands-native"
+  npm_config_registry=https://registry.npmjs.org/ \
+    npm create deepseek-harness-action@0.2.0 -- --mode commands --dsh-mode native
+)
+(
+  cd "$installer_stage/public-both"
+  npm_config_registry=https://registry.npmjs.org/ \
+    npm create deepseek-harness-action@0.2.0 -- --mode both
+)
+```
+
+Confirm the review, commands, and both file sets are correct; controlled remains
+the default; native is explicit; every workflow parses as YAML and contains
+exactly one `release_sha` Action reference; and checkout, permission, Docker,
+validation, credential, and overwrite boundaries remain intact. Then remove the
+disposable worktree and staging directory. npm versions and both release tags
+are immutable; a bad published installer must be fixed with a new installer
+patch version rather than replacing `0.2.0`.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -26,7 +26,21 @@ For CI or another non-interactive environment, pass the mode explicitly. The ins
 npm create deepseek-harness-action@latest -- --mode both
 ```
 
-The installer creates `.github/workflows/` when necessary and refuses to overwrite an existing target workflow. It does not add `DEEPSEEK_API_KEY`, commit or push changes, or open a pull request. Installer v0.1.1 generates workflows pinned to the immutable v0.6.0 release commit.
+For non-interactive use, omitting `--dsh-mode` keeps the compatible `controlled`
+default. The interactive flow asks explicitly; choose Controlled there unless
+native composition is intended:
+
+```bash
+npm create deepseek-harness-action@latest -- --mode both --dsh-mode native
+```
+
+The installer creates `.github/workflows/` when necessary and refuses to
+overwrite an existing target workflow. It does not add `DEEPSEEK_API_KEY`,
+commit or push changes, or open a pull request. Installer v0.2.0 is built only
+after the formal v0.8.0 tag, GitHub Release, and release canary agree; its
+workflows pin immutable commit
+`86fff4c4527694c7eefdc65c6cf7a633b5ea8cb1`, not a candidate SHA, floating tag,
+or branch.
 
 After the installer succeeds:
 
@@ -70,7 +84,15 @@ The examples use the current release tag for readability:
 uses: Lixiaoyiao/deepseek-harness-action@v0.8.0
 ```
 
-For production, replace the tag with the full immutable commit SHA published for that release. Do not use `main`, `latest`, a version range, or another floating ref. Keep `dsh-version` at the Action's audited exact value:
+For production, replace the tag with the full immutable commit SHA published
+for that release. The formal v0.8.0 commit is:
+
+```yaml
+uses: Lixiaoyiao/deepseek-harness-action@86fff4c4527694c7eefdc65c6cf7a633b5ea8cb1
+```
+
+Do not use `main`, `latest`, a version range, a candidate SHA, or another
+floating ref. Keep `dsh-version` at the Action's audited exact value:
 
 ```yaml
 with:

--- a/docs/setup.zh-CN.md
+++ b/docs/setup.zh-CN.md
@@ -26,7 +26,19 @@ npm create deepseek-harness-action@latest
 npm create deepseek-harness-action@latest -- --mode both
 ```
 
-安装器会按需创建 `.github/workflows/`，如果目标 workflow 已存在则拒绝覆盖。它不会添加 `DEEPSEEK_API_KEY`、commit 或 push 改动，也不会创建 PR。安装器 v0.1.1 生成的 workflow 会把 Action 固定到 v0.6.0 的不可变 release commit。
+非交互使用时，省略 `--dsh-mode` 会保持兼容的 `controlled` 默认值。交互流程
+会明确询问；除非确实需要 native composition，否则请选择 Controlled：
+
+```bash
+npm create deepseek-harness-action@latest -- --mode both --dsh-mode native
+```
+
+安装器会按需创建 `.github/workflows/`，如果目标 workflow 已存在则拒绝覆盖。
+它不会添加 `DEEPSEEK_API_KEY`、commit 或 push 改动，也不会创建 PR。安装器
+v0.2.0 只在正式 v0.8.0 Tag、GitHub Release 与 release canary 身份一致后
+构建；生成的 workflow 固定到不可变 commit
+`86fff4c4527694c7eefdc65c6cf7a633b5ea8cb1`，不会使用 candidate SHA、浮动 Tag
+或分支。
 
 安装成功后：
 
@@ -70,7 +82,15 @@ DEEPSEEK_API_KEY
 uses: Lixiaoyiao/deepseek-harness-action@v0.8.0
 ```
 
-生产环境应把 Tag 替换为该版本发布时的完整、不可变 commit SHA。不要使用 `main`、`latest`、版本范围或其它浮动 ref。`dsh-version` 必须保持为本版本审计过的精确值：
+生产环境应把 Tag 替换为该版本发布时的完整、不可变 commit SHA。正式
+v0.8.0 commit 是：
+
+```yaml
+uses: Lixiaoyiao/deepseek-harness-action@86fff4c4527694c7eefdc65c6cf7a633b5ea8cb1
+```
+
+不要使用 `main`、`latest`、版本范围、candidate SHA 或其它浮动 ref。
+`dsh-version` 必须保持为本版本审计过的精确值：
 
 ```yaml
 with:

--- a/packages/create-deepseek-harness-action/README.md
+++ b/packages/create-deepseek-harness-action/README.md
@@ -8,16 +8,26 @@ npm create deepseek-harness-action@latest
 ```
 
 The interactive installer offers **PR Review**, **@dsh Coding Commands**, or
-**Both**. For non-interactive use, select the mode explicitly:
+**Both**, then lets you keep the compatible `controlled` DSH composition or
+explicitly select `native`. For non-interactive use, select the workflow mode
+explicitly; omitting `--dsh-mode` keeps `controlled`:
 
 ```bash
 npm create deepseek-harness-action@latest -- --mode both
 ```
 
-Valid modes are `review`, `commands`, and `both`. The installer creates only
-workflow files. It does not add secrets, commit, push, or open a pull request.
-Existing workflow files are never overwritten.
+To generate native-mode workflows explicitly:
 
-Version `0.1.1` is built only after the formal Action release exists. Its
-generated workflows pin the immutable v0.6.0 release commit, not a floating
-tag or branch.
+```bash
+npm create deepseek-harness-action@latest -- --mode both --dsh-mode native
+```
+
+Valid workflow modes are `review`, `commands`, and `both`; valid DSH modes are
+`controlled` and `native`. The installer creates only workflow files. It does
+not add secrets, commit, push, or open a pull request. Existing workflow files
+are never overwritten.
+
+Version `0.2.0` is built only after the formal v0.8.0 Action tag, GitHub Release,
+and release canary agree. Its generated workflows pin the immutable v0.8.0
+release commit `86fff4c4527694c7eefdc65c6cf7a633b5ea8cb1`, never a candidate SHA,
+floating tag, or branch. The audited DSH version remains `0.1.1-rc.2`.

--- a/packages/create-deepseek-harness-action/package-lock.json
+++ b/packages/create-deepseek-harness-action/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-deepseek-harness-action",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-deepseek-harness-action",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "bin": {
         "create-deepseek-harness-action": "dist/cli.mjs"

--- a/packages/create-deepseek-harness-action/package.json
+++ b/packages/create-deepseek-harness-action/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-deepseek-harness-action",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Create safe DeepSeek Harness GitHub workflows",
   "private": false,
   "type": "module",

--- a/packages/create-deepseek-harness-action/scripts/build.mjs
+++ b/packages/create-deepseek-harness-action/scripts/build.mjs
@@ -4,6 +4,9 @@ import { dirname, isAbsolute, join, parse, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const RELEASE_TOKEN = "__DSH_ACTION_RELEASE_SHA__";
+const DSH_MODE_TOKEN = "__DSH_MODE_INPUT__";
+const DSH_MODE_ANCHOR = /^([ \t]*)# __DSH_MODE_INPUT__[ \t]*(\r?\n|$)/mu;
+const ACTION_REFERENCE_PATTERN = /uses: Lixiaoyiao\/deepseek-harness-action@[0-9a-f]{40}(?:\s|$)/gu;
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
 function isStrictDescendant(parent, child) {
@@ -54,29 +57,62 @@ if (releaseSha === undefined || !/^[0-9a-f]{40}$/u.test(releaseSha)) {
 
 const destination = outputDirectory(process.argv.slice(2));
 const runtimeFiles = ["cli.mjs", "installer.mjs"];
-const templateFiles = ["dsh-review.yml", "dsh-commands.yml"];
+const sourceTemplateFiles = ["dsh-review.yml", "dsh-commands.yml"];
 const runtime = new Map();
 const templates = new Map();
 
+function nativeTemplateName(sourceFile) {
+  return sourceFile.replace(/\.yml$/u, "-native.yml");
+}
+
+function renderTemplate(source, sourceFile, dshMode) {
+  const releaseOccurrences = source.split(RELEASE_TOKEN).length - 1;
+  if (releaseOccurrences !== 1) {
+    throw new Error(`Template ${sourceFile} must contain exactly one release placeholder`);
+  }
+  const modeOccurrences = source.split(DSH_MODE_TOKEN).length - 1;
+  if (modeOccurrences !== 1 || !DSH_MODE_ANCHOR.test(source)) {
+    throw new Error(`Template ${sourceFile} must contain exactly one DSH mode build anchor`);
+  }
+
+  const withRelease = source.replace(RELEASE_TOKEN, releaseSha);
+  const built = withRelease.replace(DSH_MODE_ANCHOR, (_anchor, indentation, newline) =>
+    dshMode === "native" ? `${indentation}dsh-mode: native${newline}` : "",
+  );
+
+  if (built.includes(RELEASE_TOKEN) || built.includes(DSH_MODE_TOKEN)) {
+    throw new Error(`Template ${sourceFile} still contains a build placeholder after rendering`);
+  }
+  if ((built.match(ACTION_REFERENCE_PATTERN) ?? []).length !== 1) {
+    throw new Error(`Template ${sourceFile} must contain exactly one immutable Action reference`);
+  }
+  const modeLines = built.match(/^\s*dsh-mode:\s*\S+\s*$/gmu) ?? [];
+  if (dshMode === "controlled" && modeLines.length !== 0) {
+    throw new Error(`Controlled template ${sourceFile} must not contain dsh-mode`);
+  }
+  if (
+    dshMode === "native" &&
+    (modeLines.length !== 1 || modeLines[0]?.trim() !== "dsh-mode: native")
+  ) {
+    throw new Error(
+      `Native template ${sourceFile} must contain exactly one dsh-mode: native input`,
+    );
+  }
+  return built;
+}
+
 for (const file of runtimeFiles) {
   const contents = await readFile(join(packageRoot, "src", file), "utf8");
-  if (contents.includes(RELEASE_TOKEN)) {
-    throw new Error(`Runtime file ${file} must not contain the release placeholder`);
+  if (contents.includes(RELEASE_TOKEN) || contents.includes(DSH_MODE_TOKEN)) {
+    throw new Error(`Runtime file ${file} must not contain a build placeholder`);
   }
   runtime.set(file, contents);
 }
 
-for (const file of templateFiles) {
+for (const file of sourceTemplateFiles) {
   const source = await readFile(join(packageRoot, "src", "templates", file), "utf8");
-  const occurrences = source.split(RELEASE_TOKEN).length - 1;
-  if (occurrences !== 1) {
-    throw new Error(`Template ${file} must contain exactly one release placeholder`);
-  }
-  const built = source.replace(RELEASE_TOKEN, releaseSha);
-  if (built.includes(RELEASE_TOKEN)) {
-    throw new Error(`Template ${file} still contains the release placeholder after build`);
-  }
-  templates.set(file, built);
+  templates.set(file, renderTemplate(source, file, "controlled"));
+  templates.set(nativeTemplateName(file), renderTemplate(source, file, "native"));
 }
 
 await rm(destination, { force: true, recursive: true });
@@ -88,8 +124,8 @@ for (const [file, contents] of templates) {
 await chmod(join(destination, "cli.mjs"), 0o755);
 
 for (const [file, contents] of [...runtime, ...templates]) {
-  if (contents.includes(RELEASE_TOKEN)) {
-    throw new Error(`Refusing to publish release placeholder from ${file}`);
+  if (contents.includes(RELEASE_TOKEN) || contents.includes(DSH_MODE_TOKEN)) {
+    throw new Error(`Refusing to publish build placeholder from ${file}`);
   }
 }
 

--- a/packages/create-deepseek-harness-action/src/installer.d.mts
+++ b/packages/create-deepseek-harness-action/src/installer.d.mts
@@ -1,6 +1,7 @@
 import type { Readable, Writable } from "node:stream";
 
 export type InstallerMode = "review" | "commands" | "both";
+export type InstallerDshMode = "controlled" | "native";
 
 export interface InstallerOptions {
   readonly argv?: readonly string[];
@@ -14,12 +15,14 @@ export interface InstallerOptions {
 
 export interface InstallerResult {
   readonly mode?: InstallerMode;
+  readonly dshMode: InstallerDshMode;
   readonly createdFiles: readonly string[];
 }
 
 export function parseArguments(argv: readonly string[]): {
   readonly help: boolean;
   readonly mode: InstallerMode | undefined;
+  readonly dshMode: InstallerDshMode | undefined;
 };
 
 export function runInstaller(options?: InstallerOptions): Promise<InstallerResult>;

--- a/packages/create-deepseek-harness-action/src/installer.mjs
+++ b/packages/create-deepseek-harness-action/src/installer.mjs
@@ -5,35 +5,54 @@ import { join, resolve } from "node:path";
 import { createInterface } from "node:readline/promises";
 
 const DOCUMENTATION_URL =
-  "https://github.com/Lixiaoyiao/deepseek-harness-action/blob/v0.6.0/docs/setup.md";
+  "https://github.com/Lixiaoyiao/deepseek-harness-action/blob/v0.8.0/docs/setup.md";
 const ACTION_REFERENCE_PATTERN = /uses: Lixiaoyiao\/deepseek-harness-action@[0-9a-f]{40}(?:\s|$)/gu;
 const MODES = new Set(["review", "commands", "both"]);
+const DSH_MODES = new Set(["controlled", "native"]);
+const DEFAULT_DSH_MODE = "controlled";
 const WORKFLOWS = Object.freeze({
-  review: Object.freeze({
-    source: "dsh-review.yml",
-    target: ".github/workflows/dsh-review.yml",
+  controlled: Object.freeze({
+    review: Object.freeze({
+      source: "dsh-review.yml",
+      target: ".github/workflows/dsh-review.yml",
+    }),
+    commands: Object.freeze({
+      source: "dsh-commands.yml",
+      target: ".github/workflows/dsh-commands.yml",
+    }),
   }),
-  commands: Object.freeze({
-    source: "dsh-commands.yml",
-    target: ".github/workflows/dsh-commands.yml",
+  native: Object.freeze({
+    review: Object.freeze({
+      source: "dsh-review-native.yml",
+      target: ".github/workflows/dsh-review.yml",
+    }),
+    commands: Object.freeze({
+      source: "dsh-commands-native.yml",
+      target: ".github/workflows/dsh-commands.yml",
+    }),
   }),
 });
 
 function usage() {
   return [
-    "Usage: create-deepseek-harness-action [--mode review|commands|both]",
+    "Usage: create-deepseek-harness-action [--mode review|commands|both] [--dsh-mode controlled|native]",
     "",
-    "Interactive choices:",
+    "Workflow choices:",
     "  1) PR Review",
     "  2) @dsh Coding Commands",
     "  3) Both",
     "",
-    "CI/non-interactive usage requires --mode.",
+    "DSH mode choices:",
+    "  1) Controlled (default for non-interactive use)",
+    "  2) Native",
+    "",
+    "CI/non-interactive usage requires --mode; --dsh-mode defaults to controlled.",
   ].join("\n");
 }
 
 export function parseArguments(argv) {
   let mode;
+  let dshMode;
   let help = false;
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -43,61 +62,120 @@ export function parseArguments(argv) {
       continue;
     }
 
+    let option;
     let value;
     if (argument === "--mode") {
+      option = "mode";
       value = argv[index + 1];
       index += 1;
     } else if (argument?.startsWith("--mode=")) {
+      option = "mode";
       value = argument.slice("--mode=".length);
+    } else if (argument === "--dsh-mode") {
+      option = "dsh-mode";
+      value = argv[index + 1];
+      index += 1;
+    } else if (argument?.startsWith("--dsh-mode=")) {
+      option = "dsh-mode";
+      value = argument.slice("--dsh-mode=".length);
     } else {
       throw new Error(`Unknown argument: ${argument ?? ""}\n\n${usage()}`);
     }
 
-    if (mode !== undefined) throw new Error("--mode may be provided only once");
-    if (value === undefined || value === "") {
-      throw new Error(`--mode requires review, commands, or both\n\n${usage()}`);
+    if (option === "mode") {
+      if (mode !== undefined) throw new Error("--mode may be provided only once");
+      if (value === undefined || value === "" || value.startsWith("--")) {
+        throw new Error(`--mode requires review, commands, or both\n\n${usage()}`);
+      }
+      if (!MODES.has(value)) {
+        throw new Error(`Invalid --mode value: ${value}\n\n${usage()}`);
+      }
+      mode = value;
+      continue;
     }
-    if (!MODES.has(value)) {
-      throw new Error(`Invalid --mode value: ${value}\n\n${usage()}`);
+
+    if (dshMode !== undefined) throw new Error("--dsh-mode may be provided only once");
+    if (value === undefined || value === "" || value.startsWith("--")) {
+      throw new Error(`--dsh-mode requires controlled or native\n\n${usage()}`);
     }
-    mode = value;
+    if (!DSH_MODES.has(value)) {
+      throw new Error(`Invalid --dsh-mode value: ${value}\n\n${usage()}`);
+    }
+    dshMode = value;
   }
 
-  return { help, mode };
+  return { help, mode, dshMode };
 }
 
-async function promptForMode(input, output) {
-  const readline = createInterface({ input, output, terminal: false });
-  try {
-    while (true) {
-      const answer = (
-        await readline.question(
-          [
-            "Choose what to install:\n",
-            "  1) PR Review\n",
-            "  2) @dsh Coding Commands\n",
-            "  3) Both\n",
-            "Selection [1-3]: ",
-          ].join(""),
-        )
+async function promptForMode(readline, output) {
+  while (true) {
+    const answer = (
+      await readline.question(
+        [
+          "Choose what to install:\n",
+          "  1) PR Review\n",
+          "  2) @dsh Coding Commands\n",
+          "  3) Both\n",
+          "Selection [1-3]: ",
+        ].join(""),
       )
-        .trim()
-        .toLowerCase();
+    )
+      .trim()
+      .toLowerCase();
 
-      if (answer === "1" || answer === "review") return "review";
-      if (answer === "2" || answer === "commands") return "commands";
-      if (answer === "3" || answer === "both") return "both";
-      output.write("Please enter 1, 2, or 3.\n");
-    }
+    if (answer === "1" || answer === "review") return "review";
+    if (answer === "2" || answer === "commands") return "commands";
+    if (answer === "3" || answer === "both") return "both";
+    output.write("Please enter 1, 2, or 3.\n");
+  }
+}
+
+async function promptForDshMode(readline, output) {
+  while (true) {
+    const answer = (
+      await readline.question(
+        ["Choose the DSH mode:\n", "  1) Controlled\n", "  2) Native\n", "Selection [1-2]: "].join(
+          "",
+        ),
+      )
+    )
+      .trim()
+      .toLowerCase();
+
+    if (answer === "1" || answer === "controlled") return "controlled";
+    if (answer === "2" || answer === "native") return "native";
+    output.write("Please enter 1 or 2.\n");
+  }
+}
+
+async function promptForMissingSelections({ input, output, mode, dshMode }) {
+  const readline = createInterface({ input, output, terminal: false });
+  const answers = readline[Symbol.asyncIterator]();
+  const prompt = {
+    async question(message) {
+      output.write(message);
+      const answer = await answers.next();
+      if (answer.done) {
+        throw new Error("Interactive input ended before all installer choices were selected");
+      }
+      return answer.value;
+    },
+  };
+  try {
+    return {
+      mode: mode ?? (await promptForMode(prompt, output)),
+      dshMode: dshMode ?? (await promptForDshMode(prompt, output)),
+    };
   } finally {
     readline.close();
   }
 }
 
-function workflowDefinitions(mode) {
-  if (mode === "review") return [WORKFLOWS.review];
-  if (mode === "commands") return [WORKFLOWS.commands];
-  return [WORKFLOWS.review, WORKFLOWS.commands];
+function workflowDefinitions(mode, dshMode) {
+  const workflows = WORKFLOWS[dshMode];
+  if (mode === "review") return [workflows.review];
+  if (mode === "commands") return [workflows.commands];
+  return [workflows.review, workflows.commands];
 }
 
 async function pathExists(path) {
@@ -119,8 +197,8 @@ function assertReleaseBuiltTemplate(contents, source) {
   }
 }
 
-async function installWorkflows({ cwd, mode, templateDirectory }) {
-  const definitions = workflowDefinitions(mode).map((definition) => ({
+async function installWorkflows({ cwd, mode, dshMode, templateDirectory }) {
+  const definitions = workflowDefinitions(mode, dshMode).map((definition) => ({
     ...definition,
     absoluteTarget: join(cwd, ...definition.target.split("/")),
   }));
@@ -166,9 +244,10 @@ async function installWorkflows({ cwd, mode, templateDirectory }) {
   return created.map(({ target }) => target);
 }
 
-function printSuccess(output, mode, createdFiles) {
+function printSuccess(output, mode, dshMode, createdFiles) {
   output.write("\nCreated workflow files:\n");
   for (const path of createdFiles) output.write(`  - ${path}\n`);
+  output.write(`\nDSH mode: ${dshMode}\n`);
 
   output.write(
     [
@@ -214,20 +293,26 @@ export async function runInstaller(options = {}) {
 
   if (parsed.help) {
     output.write(`${usage()}\n`);
-    return { createdFiles: [] };
+    return { dshMode: parsed.dshMode ?? DEFAULT_DSH_MODE, createdFiles: [] };
   }
 
   let mode = parsed.mode;
+  let dshMode = parsed.dshMode;
+  const interactive = isTTY && !environment.CI;
   if (mode === undefined) {
-    if (!isTTY || Boolean(environment.CI)) {
+    if (!interactive) {
       throw new Error(
         `Non-interactive or CI input requires --mode review|commands|both\n\n${usage()}`,
       );
     }
-    mode = await promptForMode(input, output);
   }
 
-  const createdFiles = await installWorkflows({ cwd, mode, templateDirectory });
-  printSuccess(output, mode, createdFiles);
-  return { mode, createdFiles };
+  if (interactive && (mode === undefined || dshMode === undefined)) {
+    ({ mode, dshMode } = await promptForMissingSelections({ input, output, mode, dshMode }));
+  }
+  dshMode ??= DEFAULT_DSH_MODE;
+
+  const createdFiles = await installWorkflows({ cwd, mode, dshMode, templateDirectory });
+  printSuccess(output, mode, dshMode, createdFiles);
+  return { mode, dshMode, createdFiles };
 }

--- a/packages/create-deepseek-harness-action/src/templates/dsh-commands.yml
+++ b/packages/create-deepseek-harness-action/src/templates/dsh-commands.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: Lixiaoyiao/deepseek-harness-action@__DSH_ACTION_RELEASE_SHA__
         with:
           deepseek-api-key: ${{ secrets.DEEPSEEK_API_KEY }}
+          # __DSH_MODE_INPUT__
           dsh-version: 0.1.1-rc.2
           permission-profile: standard
           isolation: docker

--- a/packages/create-deepseek-harness-action/src/templates/dsh-review.yml
+++ b/packages/create-deepseek-harness-action/src/templates/dsh-review.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: Lixiaoyiao/deepseek-harness-action@__DSH_ACTION_RELEASE_SHA__
         with:
           deepseek-api-key: ${{ secrets.DEEPSEEK_API_KEY }}
+          # __DSH_MODE_INPUT__
           dsh-version: 0.1.1-rc.2
           permission-profile: strict
           isolation: docker

--- a/scripts/verify-release-contract.mjs
+++ b/scripts/verify-release-contract.mjs
@@ -22,6 +22,13 @@ const [
   canary,
   installerManifestText,
   installerLockText,
+  installerReadme,
+  rootReadme,
+  rootReadmeZh,
+  setupGuide,
+  setupGuideZh,
+  changelog,
+  maintainerReleaseGuide,
   installerBuild,
   installerRuntime,
   installerReview,
@@ -34,6 +41,13 @@ const [
   read(".github/workflows/release-canary.yml"),
   read("packages/create-deepseek-harness-action/package.json"),
   read("packages/create-deepseek-harness-action/package-lock.json"),
+  read("packages/create-deepseek-harness-action/README.md"),
+  read("README.md"),
+  read("README.zh-CN.md"),
+  read("docs/setup.md"),
+  read("docs/setup.zh-CN.md"),
+  read("CHANGELOG.md"),
+  read("docs/maintainer-release.md"),
   read("packages/create-deepseek-harness-action/scripts/build.mjs"),
   read("packages/create-deepseek-harness-action/src/installer.mjs"),
   read("packages/create-deepseek-harness-action/src/templates/dsh-review.yml"),
@@ -43,7 +57,9 @@ const manifest = JSON.parse(manifestText);
 const lock = JSON.parse(lockText);
 const installerManifest = JSON.parse(installerManifestText);
 const installerLock = JSON.parse(installerLockText);
-const installerVersion = "0.1.1";
+const installerVersion = "0.2.0";
+const installerActionTag = "v0.8.0";
+const installerActionReleaseSha = "86fff4c4527694c7eefdc65c6cf7a633b5ea8cb1";
 const directDependencies = {
   ...(manifest.dependencies ?? {}),
   ...(manifest.devDependencies ?? {}),
@@ -211,11 +227,46 @@ assert.equal(
   "installer root lock version drifted",
 );
 assert.ok(
-  installerRuntime.includes("/blob/v0.6.0/docs/setup.md"),
-  "installer documentation must bind to the v0.6.0 release",
+  installerRuntime.includes(`/blob/${installerActionTag}/docs/setup.md`),
+  `installer documentation must bind to the ${installerActionTag} release`,
 );
+assert.ok(
+  installerReadme.includes(`Version \`${installerVersion}\``) &&
+    installerReadme.includes(installerActionTag) &&
+    installerReadme.includes(installerActionReleaseSha),
+  "installer README must identify its version and immutable Action binding",
+);
+for (const [name, document] of [
+  ["README.md", rootReadme],
+  ["README.zh-CN.md", rootReadmeZh],
+  ["docs/setup.md", setupGuide],
+  ["docs/setup.zh-CN.md", setupGuideZh],
+  ["CHANGELOG.md", changelog],
+  ["docs/maintainer-release.md", maintainerReleaseGuide],
+]) {
+  assert.ok(
+    document.includes(installerVersion) &&
+      document.includes(installerActionTag) &&
+      document.includes(installerActionReleaseSha),
+    `${name} must identify the installer version and immutable Action binding`,
+  );
+}
+assert.ok(
+  maintainerReleaseGuide.includes('repository="Lixiaoyiao/deepseek-harness-action"') &&
+    !maintainerReleaseGuide.includes("$GITHUB_REPOSITORY"),
+  "installer publish guide must use an explicit repository identity",
+);
+assert.ok(
+  installerRuntime.includes("--dsh-mode controlled|native") &&
+    installerRuntime.includes('const DEFAULT_DSH_MODE = "controlled"'),
+  "installer CLI must expose native as an opt-in and keep controlled as the default",
+);
+for (const expected of ["dsh-review-native.yml", "dsh-commands-native.yml"]) {
+  assert.ok(installerRuntime.includes(expected), `installer runtime is missing: ${expected}`);
+}
 
 const installerReleaseToken = "__DSH_ACTION_RELEASE_SHA__";
+const installerDshModeToken = "__DSH_MODE_INPUT__";
 assert.ok(
   installerBuild.includes("DSH_ACTION_RELEASE_SHA"),
   "installer build must require an explicit release SHA",
@@ -223,6 +274,16 @@ assert.ok(
 assert.ok(
   installerBuild.includes("^[0-9a-f]{40}$"),
   "installer build must accept only a lowercase full commit SHA",
+);
+assert.ok(
+  installerBuild.includes(installerDshModeToken) &&
+    installerBuild.includes('renderTemplate(source, file, "controlled")') &&
+    installerBuild.includes('renderTemplate(source, file, "native")'),
+  "installer build must deterministically render controlled and native templates",
+);
+assert.ok(
+  !installerBuild.includes(installerActionReleaseSha),
+  "installer source build must receive the formal Action SHA only through DSH_ACTION_RELEASE_SHA",
 );
 for (const [name, template] of [
   ["review", installerReview],
@@ -232,6 +293,16 @@ for (const [name, template] of [
     template.split(installerReleaseToken).length - 1,
     1,
     `${name} installer template must contain exactly one controlled release token`,
+  );
+  assert.equal(
+    template.split(installerDshModeToken).length - 1,
+    1,
+    `${name} installer template must contain exactly one DSH mode build anchor`,
+  );
+  assert.doesNotMatch(
+    template,
+    /^\s*dsh-mode:/mu,
+    `${name} source template must leave controlled mode implicit`,
   );
   assert.ok(
     template.includes(`Lixiaoyiao/deepseek-harness-action@${installerReleaseToken}`),

--- a/test/installer.test.ts
+++ b/test/installer.test.ts
@@ -1,5 +1,5 @@
 import { execFile, spawn } from "node:child_process";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, parse as parsePath } from "node:path";
 import { promisify } from "node:util";
@@ -11,13 +11,15 @@ import { parse } from "yaml";
 
 import {
   runInstaller,
+  type InstallerDshMode,
   type InstallerMode,
 } from "../packages/create-deepseek-harness-action/src/installer.mjs";
 
 const execFileAsync = promisify(execFile);
-const INSTALLER_VERSION = "0.1.1";
+const INSTALLER_VERSION = "0.2.0";
 const RELEASE_SHA = "1234567890abcdef1234567890abcdef12345678";
 const RELEASE_TOKEN = "__DSH_ACTION_RELEASE_SHA__";
+const DSH_MODE_TOKEN = "__DSH_MODE_INPUT__";
 const packageRoot = new URL("../packages/create-deepseek-harness-action/", import.meta.url);
 const packageRootPath = fileURLToPath(packageRoot);
 const buildScript = fileURLToPath(new URL("scripts/build.mjs", packageRoot));
@@ -55,11 +57,11 @@ async function workflow(project: string, name: "dsh-review.yml" | "dsh-commands.
   return readFile(join(project, ".github", "workflows", name), "utf8");
 }
 
-async function install(mode: InstallerMode, project?: string) {
+async function install(mode: InstallerMode, dshMode?: InstallerDshMode, project?: string) {
   const targetProject = project ?? (await createProject());
   const output = new OutputCapture();
   const result = await runInstaller({
-    argv: ["--mode", mode],
+    argv: ["--mode", mode, ...(dshMode === undefined ? [] : ["--dsh-mode", dshMode])],
     cwd: targetProject,
     input: Readable.from([]),
     output,
@@ -83,7 +85,7 @@ afterAll(async () => {
 });
 
 describe("create-deepseek-harness-action release build", () => {
-  it("declares the independent 0.1.1 npm create package", async () => {
+  it("declares the independent 0.2.0 npm create package", async () => {
     const manifest: unknown = JSON.parse(
       await readFile(new URL("package.json", packageRoot), "utf8"),
     );
@@ -101,23 +103,53 @@ describe("create-deepseek-harness-action release build", () => {
     });
   });
 
-  it("requires the real release SHA and removes every placeholder from npm dist", async () => {
-    for (const name of ["dsh-review.yml", "dsh-commands.yml"] as const) {
-      const source = await readFile(new URL(name, sourceTemplates), "utf8");
-      expect(source.split(RELEASE_TOKEN)).toHaveLength(2);
+  it("requires the real release SHA and deterministically builds four bound templates", async () => {
+    expect((await readdir(sourceTemplates)).sort()).toEqual(["dsh-commands.yml", "dsh-review.yml"]);
 
+    const repeatedBuild = join(suiteDirectory, "repeated-build");
+    await execFileAsync(process.execPath, [buildScript, "--output", repeatedBuild], {
+      env: { ...process.env, DSH_ACTION_RELEASE_SHA: RELEASE_SHA },
+      windowsHide: true,
+    });
+
+    for (const sourceName of ["dsh-review.yml", "dsh-commands.yml"] as const) {
+      const source = await readFile(new URL(sourceName, sourceTemplates), "utf8");
+      expect(source.split(RELEASE_TOKEN)).toHaveLength(2);
+      expect(source.split(DSH_MODE_TOKEN)).toHaveLength(2);
+      expect(source).not.toMatch(/^\s*dsh-mode:/mu);
+    }
+
+    for (const [name, dshMode] of [
+      ["dsh-review.yml", "controlled"],
+      ["dsh-review-native.yml", "native"],
+      ["dsh-commands.yml", "controlled"],
+      ["dsh-commands-native.yml", "native"],
+    ] as const) {
       const built = await readFile(join(builtPackage, "templates", name), "utf8");
+      await expect(readFile(join(repeatedBuild, "templates", name), "utf8")).resolves.toBe(built);
       expect(built).not.toContain(RELEASE_TOKEN);
+      expect(built).not.toContain(DSH_MODE_TOKEN);
       expect(built).toContain(`Lixiaoyiao/deepseek-harness-action@${RELEASE_SHA}`);
+      expect(built.match(new RegExp(`deepseek-harness-action@${RELEASE_SHA}`, "gu"))).toHaveLength(
+        1,
+      );
+      expect(() => {
+        parse(built);
+      }).not.toThrow();
+      if (dshMode === "controlled") {
+        expect(built).not.toMatch(/^\s*dsh-mode:/mu);
+      } else {
+        expect(built.match(/^\s*dsh-mode: native\s*$/gmu)).toHaveLength(1);
+      }
     }
 
     for (const name of ["cli.mjs", "installer.mjs"] as const) {
-      await expect(readFile(join(builtPackage, name), "utf8")).resolves.not.toContain(
-        RELEASE_TOKEN,
-      );
+      const runtime = await readFile(join(builtPackage, name), "utf8");
+      expect(runtime).not.toContain(RELEASE_TOKEN);
+      expect(runtime).not.toContain(DSH_MODE_TOKEN);
     }
     await expect(readFile(join(builtPackage, "installer.mjs"), "utf8")).resolves.toContain(
-      "/blob/v0.6.0/docs/setup.md",
+      "/blob/v0.8.0/docs/setup.md",
     );
 
     for (const [index, invalidReleaseSha] of [
@@ -164,6 +196,7 @@ describe("create-deepseek-harness-action release build", () => {
     );
     const packResult = JSON.parse(stdout) as {
       filename?: string;
+      files?: { path?: string }[];
       name?: string;
       version?: string;
     }[];
@@ -177,6 +210,14 @@ describe("create-deepseek-harness-action release build", () => {
     await expect(
       readFile(join(packDirectory, packResult[0]?.filename ?? "")),
     ).resolves.not.toHaveLength(0);
+    expect(packResult[0]?.files?.map(({ path }) => path).sort()).toEqual(
+      expect.arrayContaining([
+        "dist/templates/dsh-commands-native.yml",
+        "dist/templates/dsh-commands.yml",
+        "dist/templates/dsh-review-native.yml",
+        "dist/templates/dsh-review.yml",
+      ]),
+    );
   });
 });
 
@@ -188,8 +229,11 @@ describe("installer modes", () => {
     await expect(workflow(project, "dsh-commands.yml")).rejects.toThrow();
     expect(result).toEqual({
       mode: "review",
+      dshMode: "controlled",
       createdFiles: [".github/workflows/dsh-review.yml"],
     });
+    await expect(workflow(project, "dsh-review.yml")).resolves.not.toMatch(/^\s*dsh-mode:/mu);
+    expect(output).toContain("DSH mode: controlled");
     expect(output).toContain("DEEPSEEK_API_KEY");
     expect(output).toContain("open or update a non-draft pull request");
     expect(output).toContain("docs/setup.md");
@@ -202,6 +246,7 @@ describe("installer modes", () => {
     expect(commands).toContain("name: DSH commands");
     expect(commands).toContain("REQUIRED: Replace this fail-closed placeholder");
     expect(commands).not.toMatch(/\b(?:npm|pnpm|yarn)\b/u);
+    expect(result.dshMode).toBe("controlled");
     expect(result.createdFiles).toEqual([".github/workflows/dsh-commands.yml"]);
     expect(output).toContain("Replace the fail-closed test-commands placeholder");
     expect(output).toContain("digest-pinned container-image");
@@ -219,6 +264,7 @@ describe("installer modes", () => {
       ".github/workflows/dsh-review.yml",
       ".github/workflows/dsh-commands.yml",
     ]);
+    expect(result.dshMode).toBe("controlled");
     expect(output).toContain("dsh-review.yml");
     expect(output).toContain("dsh-commands.yml");
     expect(output).toContain("DEEPSEEK_API_KEY");
@@ -228,10 +274,52 @@ describe("installer modes", () => {
   });
 
   it.each([
-    ["1\n", "review", [".github/workflows/dsh-review.yml"]],
-    ["2\n", "commands", [".github/workflows/dsh-commands.yml"]],
-    ["3\n", "both", [".github/workflows/dsh-review.yml", ".github/workflows/dsh-commands.yml"]],
-  ] as const)("supports interactive choice %s", async (answer, mode, createdFiles) => {
+    ["review", "controlled", ["dsh-review.yml"]],
+    ["commands", "controlled", ["dsh-commands.yml"]],
+    ["both", "controlled", ["dsh-review.yml", "dsh-commands.yml"]],
+    ["review", "native", ["dsh-review.yml"]],
+    ["commands", "native", ["dsh-commands.yml"]],
+    ["both", "native", ["dsh-review.yml", "dsh-commands.yml"]],
+  ] as const)(
+    "installs the non-interactive %s/%s combination",
+    async (mode, dshMode, createdNames) => {
+      const { output, project, result } = await install(mode, dshMode);
+      expect(result).toEqual({
+        mode,
+        dshMode,
+        createdFiles: createdNames.map((name) => `.github/workflows/${name}`),
+      });
+      expect(output).toContain(`DSH mode: ${dshMode}`);
+
+      for (const name of createdNames) {
+        const contents = await workflow(project, name);
+        expect(() => {
+          parse(contents);
+        }).not.toThrow();
+        expect(
+          contents.match(new RegExp(`deepseek-harness-action@${RELEASE_SHA}`, "gu")),
+        ).toHaveLength(1);
+        expect(contents).not.toContain(RELEASE_TOKEN);
+        expect(contents).not.toContain(DSH_MODE_TOKEN);
+        if (dshMode === "controlled") {
+          expect(contents).not.toMatch(/^\s*dsh-mode:/mu);
+        } else {
+          expect(contents.match(/^\s*dsh-mode: native\s*$/gmu)).toHaveLength(1);
+        }
+      }
+    },
+  );
+
+  it.each([
+    ["1\n1\n", "review", "controlled", [".github/workflows/dsh-review.yml"]],
+    ["2\n2\n", "commands", "native", [".github/workflows/dsh-commands.yml"]],
+    [
+      "3\n1\n",
+      "both",
+      "controlled",
+      [".github/workflows/dsh-review.yml", ".github/workflows/dsh-commands.yml"],
+    ],
+  ] as const)("supports interactive choices %s", async (answer, mode, dshMode, createdFiles) => {
     const project = await createProject();
     const output = new OutputCapture();
     const result = await runInstaller({
@@ -244,35 +332,102 @@ describe("installer modes", () => {
       templateDirectory: join(builtPackage, "templates"),
     });
 
-    expect(result).toEqual({ mode, createdFiles: [...createdFiles] });
+    expect(result).toEqual({ mode, dshMode, createdFiles: [...createdFiles] });
     expect(output.text).toContain("PR Review");
     expect(output.text).toContain("@dsh Coding Commands");
     expect(output.text).toContain("Both");
+    expect(output.text).toContain("Controlled");
+    expect(output.text).toContain("Native");
+  });
+
+  it("prompts only for DSH mode when the workflow mode is explicit", async () => {
+    const project = await createProject();
+    const output = new OutputCapture();
+    const result = await runInstaller({
+      argv: ["--mode", "review"],
+      cwd: project,
+      input: Readable.from(["2\n"]),
+      output,
+      isTTY: true,
+      env: {},
+      templateDirectory: join(builtPackage, "templates"),
+    });
+
+    expect(result).toEqual({
+      mode: "review",
+      dshMode: "native",
+      createdFiles: [".github/workflows/dsh-review.yml"],
+    });
+    expect(output.text).not.toContain("Choose what to install");
+    expect(output.text).toContain("Choose the DSH mode");
+  });
+
+  it("prompts only for workflow mode when DSH mode is explicit", async () => {
+    const project = await createProject();
+    const output = new OutputCapture();
+    const result = await runInstaller({
+      argv: ["--dsh-mode", "native"],
+      cwd: project,
+      input: Readable.from(["3\n"]),
+      output,
+      isTTY: true,
+      env: {},
+      templateDirectory: join(builtPackage, "templates"),
+    });
+
+    expect(result).toEqual({
+      mode: "both",
+      dshMode: "native",
+      createdFiles: [".github/workflows/dsh-review.yml", ".github/workflows/dsh-commands.yml"],
+    });
+    expect(output.text).toContain("Choose what to install");
+    expect(output.text).not.toContain("Choose the DSH mode");
   });
 });
 
 describe("safe filesystem and non-interactive behavior", () => {
-  it("preflights Both and does not overwrite or partially create workflows", async () => {
-    const project = await createProject();
-    const workflowDirectory = join(project, ".github", "workflows");
-    const existingReview = join(workflowDirectory, "dsh-review.yml");
-    await mkdir(workflowDirectory, { recursive: true });
-    await writeFile(existingReview, "user-owned\n", "utf8");
+  it.each(["controlled", "native"] as const)(
+    "preflights Both/%s and does not overwrite or partially create workflows",
+    async (dshMode) => {
+      const project = await createProject();
+      const workflowDirectory = join(project, ".github", "workflows");
+      const existingReview = join(workflowDirectory, "dsh-review.yml");
+      await mkdir(workflowDirectory, { recursive: true });
+      await writeFile(existingReview, "user-owned\n", "utf8");
 
-    await expect(
-      runInstaller({
-        argv: ["--mode", "both"],
-        cwd: project,
-        input: Readable.from([]),
-        output: new OutputCapture(),
-        isTTY: false,
-        templateDirectory: join(builtPackage, "templates"),
-      }),
-    ).rejects.toThrow(/Refusing to overwrite.*dsh-review\.yml/su);
+      await expect(
+        runInstaller({
+          argv: ["--mode", "both", "--dsh-mode", dshMode],
+          cwd: project,
+          input: Readable.from([]),
+          output: new OutputCapture(),
+          isTTY: false,
+          templateDirectory: join(builtPackage, "templates"),
+        }),
+      ).rejects.toThrow(/Refusing to overwrite.*dsh-review\.yml/su);
 
-    await expect(readFile(existingReview, "utf8")).resolves.toBe("user-owned\n");
-    await expect(workflow(project, "dsh-commands.yml")).rejects.toThrow();
-  });
+      await expect(readFile(existingReview, "utf8")).resolves.toBe("user-owned\n");
+      await expect(workflow(project, "dsh-commands.yml")).rejects.toThrow();
+    },
+  );
+
+  it.each(["other", "", "CONTROLLED"])(
+    "rejects invalid non-interactive --dsh-mode value %j",
+    async (dshMode) => {
+      const project = await createProject();
+      await expect(
+        runInstaller({
+          argv: ["--mode", "review", `--dsh-mode=${dshMode}`],
+          cwd: project,
+          input: Readable.from([]),
+          output: new OutputCapture(),
+          isTTY: false,
+          templateDirectory: join(builtPackage, "templates"),
+        }),
+      ).rejects.toThrow(/dsh-mode requires controlled or native|Invalid --dsh-mode value/u);
+      await expect(workflow(project, "dsh-review.yml")).rejects.toThrow();
+    },
+  );
 
   it("fails immediately without --mode on non-TTY input and never reads stdin", async () => {
     let readAttempted = false;
@@ -350,80 +505,90 @@ describe("safe filesystem and non-interactive behavior", () => {
 });
 
 describe("generated workflow contracts", () => {
-  it("generates YAML 1.2 documents that preserve the consumer safety constraints", async () => {
-    const { project } = await install("both");
-    const review = await workflow(project, "dsh-review.yml");
-    const commands = await workflow(project, "dsh-commands.yml");
+  it.each(["controlled", "native"] as const)(
+    "generates %s YAML 1.2 documents that preserve the consumer safety constraints",
+    async (dshMode) => {
+      const { project } = await install("both", dshMode);
+      const review = await workflow(project, "dsh-review.yml");
+      const commands = await workflow(project, "dsh-commands.yml");
 
-    expect(() => {
-      parse(review);
-    }).not.toThrow();
-    expect(() => {
-      parse(commands);
-    }).not.toThrow();
-    const reviewDocument = parse(review) as { permissions?: Record<string, string> };
-    const commandsDocument = parse(commands) as { permissions?: Record<string, string> };
+      expect(() => {
+        parse(review);
+      }).not.toThrow();
+      expect(() => {
+        parse(commands);
+      }).not.toThrow();
+      const reviewDocument = parse(review) as { permissions?: Record<string, string> };
+      const commandsDocument = parse(commands) as { permissions?: Record<string, string> };
 
-    expect(reviewDocument.permissions).toEqual({
-      contents: "read",
-      "pull-requests": "write",
-    });
-    expect(commandsDocument.permissions).toEqual({
-      actions: "read",
-      checks: "read",
-      contents: "write",
-      issues: "write",
-      "pull-requests": "write",
-    });
+      expect(reviewDocument.permissions).toEqual({
+        contents: "read",
+        "pull-requests": "write",
+      });
+      expect(commandsDocument.permissions).toEqual({
+        actions: "read",
+        checks: "read",
+        contents: "write",
+        issues: "write",
+        "pull-requests": "write",
+      });
 
-    expect(review).toContain("pull_request_target:");
-    expect(review).not.toMatch(/^\s+pull_request:\s*$/mu);
-    expect(review).toContain("contents: read");
-    expect(review).not.toContain("contents: write");
-    expect(review).toContain("pull-requests: write");
-    expect(review).toContain("ref: ${{ github.event.pull_request.base.sha }}");
-    expect(review).not.toContain("pull_request.head");
-    expect(review).toContain("persist-credentials: false");
-    expect(review).toContain('allow-write: "false"');
-    expect(review).toContain("permission-profile: strict");
-    expect(review).toContain("isolation: docker");
+      expect(review).toContain("pull_request_target:");
+      expect(review).not.toMatch(/^\s+pull_request:\s*$/mu);
+      expect(review).toContain("contents: read");
+      expect(review).not.toContain("contents: write");
+      expect(review).toContain("pull-requests: write");
+      expect(review).toContain("ref: ${{ github.event.pull_request.base.sha }}");
+      expect(review).not.toContain("pull_request.head");
+      expect(review).toContain("persist-credentials: false");
+      expect(review).toContain('allow-write: "false"');
+      expect(review).toContain("permission-profile: strict");
+      expect(review).toContain("isolation: docker");
 
-    for (const permission of [
-      "actions: read",
-      "checks: read",
-      "contents: write",
-      "issues: write",
-      "pull-requests: write",
-    ]) {
-      expect(commands).toContain(permission);
-    }
-    expect(commands).toContain("ref: ${{ github.event.repository.default_branch }}");
-    expect(commands).toContain("persist-credentials: false");
-    expect(commands).toContain("permission-profile: standard");
-    expect(commands).toContain("isolation: docker");
-    expect(commands).toContain('allow-write: "true"');
-    expect(commands).toContain('run-tests: "true"');
-    expect(commands).toContain("validation-integrity: strict");
-    expect(commands).toContain("process.exit(1)");
-    expect(commands).toMatch(
-      /^\s+container-image: docker\.io\/library\/node:24\.18\.0-bookworm@sha256:[0-9a-f]{64}$/mu,
-    );
+      for (const permission of [
+        "actions: read",
+        "checks: read",
+        "contents: write",
+        "issues: write",
+        "pull-requests: write",
+      ]) {
+        expect(commands).toContain(permission);
+      }
+      expect(commands).toContain("ref: ${{ github.event.repository.default_branch }}");
+      expect(commands).toContain("persist-credentials: false");
+      expect(commands).toContain("permission-profile: standard");
+      expect(commands).toContain("isolation: docker");
+      expect(commands).toContain('allow-write: "true"');
+      expect(commands).toContain('run-tests: "true"');
+      expect(commands).toContain("validation-integrity: strict");
+      expect(commands).toContain("process.exit(1)");
+      expect(commands).toMatch(
+        /^\s+container-image: docker\.io\/library\/node:24\.18\.0-bookworm@sha256:[0-9a-f]{64}$/mu,
+      );
 
-    for (const contents of [review, commands]) {
-      expect(
-        contents.match(new RegExp(`deepseek-harness-action@${RELEASE_SHA}`, "gu")),
-      ).toHaveLength(1);
-      expect(contents).not.toContain(RELEASE_TOKEN);
-      expect(contents).not.toContain("github-token:");
-      expect(contents).not.toContain("id-token:");
-      expect(contents).not.toContain("secrets: inherit");
-      expect(contents).not.toContain("GITHUB_TOKEN");
-      expect(contents).not.toContain("GH_TOKEN");
-      expect(contents).not.toMatch(/^\s+env:\s*$/mu);
-      expect(contents).toContain("deepseek-api-key: ${{ secrets.DEEPSEEK_API_KEY }}");
-      expect(
-        contents.match(/uses: actions\/checkout@11d5960a326750d5838078e36cf38b85af677262/gu),
-      ).toHaveLength(1);
-    }
-  });
+      for (const contents of [review, commands]) {
+        expect(
+          contents.match(new RegExp(`deepseek-harness-action@${RELEASE_SHA}`, "gu")),
+        ).toHaveLength(1);
+        expect(contents).not.toContain(RELEASE_TOKEN);
+        expect(contents).not.toContain(DSH_MODE_TOKEN);
+        expect(contents).not.toMatch(/deepseek-harness-action@(?:main|latest|v\d)/u);
+        if (dshMode === "controlled") {
+          expect(contents).not.toMatch(/^\s*dsh-mode:/mu);
+        } else {
+          expect(contents.match(/^\s*dsh-mode: native\s*$/gmu)).toHaveLength(1);
+        }
+        expect(contents).not.toContain("github-token:");
+        expect(contents).not.toContain("id-token:");
+        expect(contents).not.toContain("secrets: inherit");
+        expect(contents).not.toContain("GITHUB_TOKEN");
+        expect(contents).not.toContain("GH_TOKEN");
+        expect(contents).not.toMatch(/^\s+env:\s*$/mu);
+        expect(contents).toContain("deepseek-api-key: ${{ secrets.DEEPSEEK_API_KEY }}");
+        expect(
+          contents.match(/uses: actions\/checkout@11d5960a326750d5838078e36cf38b85af677262/gu),
+        ).toHaveLength(1);
+      }
+    },
+  );
 });


### PR DESCRIPTION
## Summary

- release `create-deepseek-harness-action@0.2.0`
- keep `--mode review|commands|both` and add `--dsh-mode controlled|native`
- preserve `controlled` as the non-interactive default while letting the interactive flow choose explicitly
- derive controlled/native review and commands artifacts deterministically from two source templates
- bind every generated workflow at pack time to the formal v0.8.0 commit through `DSH_ACTION_RELEASE_SHA`
- update CLI help, types, release contract, maintainer runbook, English/Chinese docs, and deterministic tests

## Release and safety binding

- Action tag: `v0.8.0`
- Formal Action commit: `86fff4c4527694c7eefdc65c6cf7a633b5ea8cb1`
- Formal release canary: https://github.com/Lixiaoyiao/deepseek-harness-action/actions/runs/32875146552
- Candidate source commit: `f8043e8c472e438fc6125e078e8f2e691cc7f0c0`
- Generated workflows use the full formal 40-character Action commit, never `main`, a floating tag, or a candidate SHA.
- The installer still refuses to overwrite workflows and does not write secrets, commit, push, or open another PR.
- DSH remains exactly `0.1.1-rc.2`; this PR does not add GitHub MCP backend or Session/Resume.

## Verification

- `npm run check`: 64 test files; 783 passed, 2 skipped; release contract, exact DSH audit, and reproducible Action `dist` passed
- `test/installer.test.ts`: 27/27 passed
- packed smoke from exact candidate: `create-deepseek-harness-action-0.2.0.tgz`
- packed tarball SHA-256: `8c45cf0b6368674567e17cccdac3c74e665242a849c277d5dea4067c064060bc`
- all six `review|commands|both` x `controlled|native` packed consumers passed
- all generated YAML parsed; each workflow referenced the formal Action SHA exactly once; no build placeholder remained
- controlled default omission, explicit native input, four packed templates, reproducible build artifacts, credential-free checkout, and overwrite refusal all passed

The npm package will be published only after this PR is merged, exact-main CI succeeds, and the independent installer source tag is created.